### PR TITLE
change start onboarding api handler

### DIFF
--- a/components/dashboard/NewHireTracker.js
+++ b/components/dashboard/NewHireTracker.js
@@ -470,7 +470,6 @@ export function NewHireTracker() {
         },
         body: JSON.stringify({
           onboardingStartDate: startDate,
-          triggerAutomation: true,
         }),
       })
 
@@ -488,14 +487,15 @@ export function NewHireTracker() {
             ? {
                 ...hire,
                 onboardingStartDate: startDate,
-                onboardingStarted: true,
-                onboardingInitiationFlow: true,
+                onboardingStarted: result.record.onboardingStarted,
+                onboardingInitiationFlow: result.record.onboardingInitiationFlow,
               }
             : hire,
         ),
       )
 
-      toast.success(`Onboarding started for ${selectedHireForStartDate.name}`)
+      // Show appropriate success message
+      toast.success(result.message)
 
       setStartDateModalOpen(false)
       setSelectedHireForStartDate(null)


### PR DESCRIPTION
The new hire tracker component now calls an updated api handler that will do the following:

- If today's date is the same as the onboarding start date -> send webhook payload to the task assignment automation in make.com. Here is the payload: 
- {
            action: "initiate",
            id: applicantId,
            name: applicantName,
            email: applicantEmail,
            jobID: jobID,
            startDate: validatedDate
} 

- if the onboarding start date is in the future, set the onboarding start date and the onboarding initiation flow checkbox to true
