### PR TITLE
feat: link View Tasks button to assigned-tasks page with name pre-search

### DIFF
--- a/TASK-view-tasks-link-assigned-tasks.md
+++ b/TASK-view-tasks-link-assigned-tasks.md
@@ -1,0 +1,11 @@
+# TASK: View Tasks Link → Assigned Tasks Page
+
+**Branch:** `feat/view-tasks-link-assigned-tasks`
+**Description:** Change the "View Tasks" button in the New Hire Details modal to link to `/admin/assigned-tasks` with the hire's name pre-populated in the search bar.
+
+## Sub-tasks
+
+- [x] Update "View Tasks" link href in `NewHireTracker.js` to `/admin/assigned-tasks?search=<hireName>`
+- [x] Make `AssignedTasksLogsPage` read `search` URL param via `useSearchParams` and pass as `initialSearchTerm`
+- [x] Add `initialSearchTerm` prop to `AssignedTasksLogsTable` and initialise `searchTerm` state with it
+- [x] Add `initialTerm` prop to `TableFilters` and initialise its local `term` state with it

--- a/components/dashboard/NewHireTracker.js
+++ b/components/dashboard/NewHireTracker.js
@@ -1134,7 +1134,7 @@ export function NewHireTracker({ initialNewHires = [] }) {
 
                       {/* View Tasks Button */}
                       <a
-                        href={`/admin/users?applicantId=${hire.id}`}
+                        href={`/admin/assigned-tasks?search=${encodeURIComponent(hire.name)}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center justify-between w-full rounded-lg border border-border/60 bg-muted/20 hover:bg-muted/40 hover:border-border px-4 py-3 transition-all group"

--- a/components/tasks/AssignedTasksLogsPage.js
+++ b/components/tasks/AssignedTasksLogsPage.js
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useSearchParams } from "next/navigation"
 import { Button } from "@components/ui/button"
 import { Plus } from "lucide-react"
 import { AssignedTasksLogsTable } from "./AssignedTasksLogsTable"
@@ -9,6 +10,8 @@ import { CreateTaskDialog } from "./CreateTaskDialog"
 export function AssignedTasksLogsPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [selectedTasks, setSelectedTasks] = useState([])
+  const searchParams = useSearchParams()
+  const initialSearchTerm = searchParams.get("search") || ""
 
   return (
     <div className="space-y-6">
@@ -22,7 +25,7 @@ export function AssignedTasksLogsPage() {
           Create Task
         </Button>
       </div>
-      <AssignedTasksLogsTable onSelectionChange={setSelectedTasks} />
+      <AssignedTasksLogsTable onSelectionChange={setSelectedTasks} initialSearchTerm={initialSearchTerm} />
       <CreateTaskDialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen} />
     </div>
   )

--- a/components/tasks/AssignedTasksLogsTable.js
+++ b/components/tasks/AssignedTasksLogsTable.js
@@ -192,8 +192,9 @@ function TableFilters({
   onRefresh,
   viewMode,
   onViewModeChange,
+  initialTerm = "",
 }) {
-  const [term, setTerm] = useState("")
+  const [term, setTerm] = useState(initialTerm)
   const debouncedTerm = useDebounce(term, 300)
   const [isFocused, setIsFocused] = useState(false)
 
@@ -446,7 +447,7 @@ const COLUMN_FIELD_MAP = {
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
-export function AssignedTasksLogsTable({ onSelectionChange }) {
+export function AssignedTasksLogsTable({ onSelectionChange, initialSearchTerm = "" }) {
   const [logs, setLogs] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -464,7 +465,7 @@ export function AssignedTasksLogsTable({ onSelectionChange }) {
   const [expandedRows, setExpandedRows] = useState({})
 
   // Filters
-  const [searchTerm, setSearchTerm] = useState("")
+  const [searchTerm, setSearchTerm] = useState(initialSearchTerm)
   const [statusFilter, setStatusFilter] = useState("all")
   const [folderFilter, setFolderFilter] = useState("all")
   const [hasDocumentsFilter, setHasDocumentsFilter] = useState("all")
@@ -978,6 +979,7 @@ export function AssignedTasksLogsTable({ onSelectionChange }) {
         onRefresh={handleRefresh}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        initialTerm={initialSearchTerm}
       />
 
       {/* Expand / Collapse all (grouped view only) */}


### PR DESCRIPTION
## Summary

- Changed the **View Tasks** button in the New Hire Details modal from pointing to `/admin/users?applicantId=...` to `/admin/assigned-tasks?search=<hireName>`
- `AssignedTasksLogsPage` now reads the `search` URL param via `useSearchParams` and passes it as `initialSearchTerm` to `AssignedTasksLogsTable`
- `AssignedTasksLogsTable` and its inner `TableFilters` component now accept an initial search term, pre-populating both the active filter state and the visible input on page load

## Completed Tasks

- [x] Update "View Tasks" link href in `NewHireTracker.js` to `/admin/assigned-tasks?search=<hireName>`
- [x] Make `AssignedTasksLogsPage` read `search` URL param via `useSearchParams` and pass as `initialSearchTerm`
- [x] Add `initialSearchTerm` prop to `AssignedTasksLogsTable` and initialise `searchTerm` state with it
- [x] Add `initialTerm` prop to `TableFilters` and initialise its local `term` state with it

## Test Plan

- [ ] Open the New Hire Tracker on the admin dashboard
- [ ] Click on a new hire card to open the Details modal
- [ ] Click **View Tasks** — should open `/admin/assigned-tasks` in a new tab with the hire's name pre-filled in the search bar and results filtered accordingly
- [ ] Verify that a hire whose name contains spaces or special characters is encoded correctly in the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)