### PR TITLE
fix: harden admin invite workflow (6 bugs)

### DIFF
--- a/TASK-admin-invite-workflow-audit.md
+++ b/TASK-admin-invite-workflow-audit.md
@@ -1,7 +1,7 @@
 # TASK: Admin Invite Workflow Audit
 
-**Branch:** `master` (documentation only — no code changes in this file)
-**Status:** Research complete. Bugs documented. Awaiting implementation decisions.
+**Branch:** `fix/admin-invite-bugs`
+**Status:** All bugs implemented. Awaiting PR.
 
 ---
 

--- a/TASK-admin-invite-workflow-audit.md
+++ b/TASK-admin-invite-workflow-audit.md
@@ -1,0 +1,311 @@
+# TASK: Admin Invite Workflow Audit
+
+**Branch:** `master` (documentation only — no code changes in this file)
+**Status:** Research complete. Bugs documented. Awaiting implementation decisions.
+
+---
+
+> ⚠️ **FOR ANY CLAUDE INSTANCE PICKING UP THIS TASK:**
+> Before implementing any solution below, read the current state of every referenced file.
+> Code may have changed since this document was written. Validate the root cause still exists
+> in its described form before making changes. Never implement blindly from this document.
+
+---
+
+## Full Workflow: Creating a New Admin
+
+### Overview
+The admin invite flow creates a Staff record in Airtable, emails an invite link via Make.com, and lets the invitee set their password through a dedicated page.
+
+---
+
+### Step 1 — UI: Admin triggers the invite
+**File:** `src/app/admin/profile/page.js` (function `sendInvite`, ~line 173)
+
+- Admin clicks "Create Admin" on the Profile page.
+- A two-step dialog opens: enter name + email, then confirm.
+- On confirm, POSTs `{ name, email }` to `/api/admin/invite-admin`.
+
+---
+
+### Step 2 — API: Staff record created and invite link generated
+**File:** `src/app/api/admin/invite-admin/route.js`
+
+1. Verifies the requester holds a valid `admin` iron-session cookie.
+2. Validates `name` and `email` (email format checked via regex).
+3. Normalises email to lowercase.
+4. Queries Airtable `Staff` table for an existing record with that email.
+   - **Exists + has `Password`** → 400 "User already has an admin account"
+   - **Exists + no `Password`** → reuses record (re-invite scenario)
+   - **Not found** → creates new Staff record: `{ Name, Email, IsAdmin: true, Password: "" }`
+5. Generates a UUID `inviteNonce` and stores it in `Staff["Invite Nonce"]`.
+6. Signs a 24-hour JWT: `{ staffId, email, type: "admin_invite", nonce: inviteNonce }`.
+7. Builds invite link: `{APP_BASE_URL}/accept-admin-invite?token={encodeURIComponent(jwt)}`.
+8. POSTs the webhook payload to `MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE`:
+   ```json
+   {
+     "name": "<name from request>",
+     "email": "<normalised email>",
+     "inviteLink": "<full URL with JWT>",
+     "requestedBy": "<requester email>",
+     "requestedAt": "<ISO timestamp>"
+   }
+   ```
+9. Checks `webhookRes.ok` — returns 502 if not OK.
+10. Logs audit event to `Website Audit Log` Airtable table.
+11. Returns `{ message: "Invite sent", staffId }`.
+
+---
+
+### Step 3 — Make.com: Email sent to invitee
+**File:** `docs/handover/automations/onboarding/ADMIN_INVITE_EMAIL.json`
+
+The Make.com scenario is triggered by the webhook. It runs **instantly on arrival (async)** — confirmed.
+
+| Module | Action |
+|--------|--------|
+| 1 | Receives webhook payload (`gateway:CustomWebHook`) |
+| 2 | Sends HTML email via `managers@smilecliniq.com` Gmail (`google-email:ActionSendEmail`) |
+| 3 | Responds `{"success": true, "messageId": "..."}` with HTTP 200 (`gateway:WebhookRespond`) |
+| Error on 2 | Responds `{"success": false, "error": "..."}` with HTTP 500 |
+
+The email addresses the user as `{{1.name}}` and links them to `{{1.inviteLink}}`.
+
+> **Key fact:** Because this is an **async/instant webhook**, Make.com responds with HTTP 200
+> immediately on receipt — **before** Module 2 (send email) has run. This means the HTTP 200
+> response the API receives does NOT confirm that the email was sent.
+
+---
+
+### Step 4 — UI: Invitee sets their password
+**File:** `src/app/accept-admin-invite/page.js`
+
+- Invitee opens the link from their email.
+- JWT is read from `?token=` query param via `useSearchParams`.
+- They fill in password + confirm password.
+- Client validates: 8+ chars, special char required, no consecutive sequences (`012`, `123`, etc.).
+- POSTs `{ token, password, confirmPassword }` to `/api/admin/accept-invite`.
+
+---
+
+### Step 5 — API: Account finalised, session created
+**File:** `src/app/api/admin/accept-invite/route.js`
+
+1. Validates password rules (same as client-side).
+2. Verifies JWT signature with `JWT_SECRET`.
+3. Extracts `{ staffId, email, type, nonce }` from JWT payload.
+4. Validates `type === "admin_invite"`.
+5. Fetches Staff record by `staffId`; confirms email matches JWT.
+6. Blocks if `Password` is already set — prevents token reuse.
+7. Compares JWT `nonce` against `Staff["Invite Nonce"]` — rejects if mismatched or empty.
+8. Bcrypt-hashes the password (10 salt rounds).
+9. Updates Staff: `{ Password: hash, IsAdmin: true, "Invite Nonce": "" }`.
+10. Creates iron-session cookie: `{ userEmail, userRole: "admin", userName, userStaffId }`, TTL 8h.
+11. Logs audit event.
+12. Returns `{ redirect: "/admin/dashboard" }` → client calls `router.push()`.
+
+---
+
+### Airtable Tables Involved
+
+| Table | Fields Written |
+|-------|---------------|
+| `Staff` | `Name`, `Email`, `Password` (hashed), `IsAdmin`, `Invite Nonce` |
+| `Website Audit Log` | `Timestamp`, `Event Type`, `Event Status`, `Role`, `Name`, `User Identifier`, `Detailed Message`, `IP Address`, `User Agent` |
+
+---
+
+## Bugs
+
+---
+
+### Bug 1 — Make.com error message swallowed in 502 response
+**Severity:** Low (original diagnosis revised — see note)  
+**File:** `src/app/api/admin/invite-admin/route.js` lines 119–128  
+**Status:** ✅ Original diagnosis corrected.
+
+**Diagnosis revision:**  
+The automation blueprint contains `gateway:WebhookRespond` modules (Module 3 on success, Module 4 on error). This is Make.com's **custom response** feature — the webhook holds the HTTP connection open and sends back the actual 200 or 500 after the modules finish. "Instant" means the scenario triggers immediately on receipt (not on a schedule), not that it responds before processing. The `webhookRes.ok` check therefore **does work correctly** and email failures are properly detected.
+
+**Remaining issue:**  
+When Make.com returns a 500, the API reads the body as text and logs it, but sends the admin a generic "Failed to trigger invite email" with no details. The Make.com error body `{"success":false, "error":"<gmail error>"}` is lost. The admin cannot tell from the response why the email failed.
+
+**Proposed solution:**  
+Parse the Make.com response body as JSON and surface the error message in the 502:
+```js
+const webhookBody = await webhookRes.json().catch(() => null)
+if (!webhookRes.ok) {
+  const makeError = webhookBody?.error || "Unknown error"
+  logger.error("Admin invite webhook failed", { status: webhookRes.status, body: webhookBody })
+  return Response.json({ error: `Failed to trigger invite email: ${makeError}` }, { status: 502 })
+}
+```
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> Confirm the Make.com error body field is `error` (not `message` or similar) by checking the blueprint's Module 4 mapper: `{"success":false, "error":"{{2.error.message}}"}` — field name is `error`. ✓
+
+---
+
+### Bug 2 — Orphaned Staff record when webhook fails
+**Severity:** Medium  
+**File:** `src/app/api/admin/invite-admin/route.js` lines 70–93 (record created/nonce set) vs lines 119–128 (webhook call)
+
+**Root cause:**
+The Staff record is created and the `Invite Nonce` is stored in Airtable **before** the webhook is called. If the webhook returns an error (or if Bug 1's fix causes it to detect a failure), the API returns 502 — but the half-initialised Staff record is left in Airtable with a dangling nonce. The admin sees an error with no indication a record was created.
+
+On retry, the code correctly finds the existing record (empty password = not configured), overwrites the nonce, and retries the webhook. The old invite link is silently invalidated. This is recoverable but invisible to the admin and creates confusing Airtable state.
+
+**Proposed solution (Option A — rollback on failure):**  
+After the webhook fails, delete the newly-created Staff record (only if it was created in this request, not an existing one):
+```js
+// Track whether we created the record in this request
+let createdInThisRequest = false
+
+if (existing.length === 0) {
+  // ... create record
+  createdInThisRequest = true
+}
+
+// ... after webhook fails:
+if (!webhookRes.ok && createdInThisRequest) {
+  await base("Staff").destroy([staffId]).catch(() => {})
+}
+return Response.json({ error: "Failed to trigger invite email" }, { status: 502 })
+```
+
+**Proposed solution (Option B — accept the state, improve the error message):**  
+Keep the current behaviour (record stays) but return a more informative error:
+```js
+return Response.json({
+  error: "Invite email failed to send. The account has been created — you can retry the invite.",
+  staffId,
+}, { status: 502 })
+```
+The frontend could surface a "Retry" action.
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> 1. Read current `invite-admin/route.js` in full to confirm the record creation and webhook call order.  
+> 2. Check whether any other code path relies on the Staff record existing before the webhook succeeds.  
+> 3. If choosing Option A, verify that `base("Staff").destroy([id])` is the correct Airtable SDK call in this codebase (check other routes that delete records for the pattern).
+
+---
+
+### Bug 3 — Re-invite does not update the `Name` field in Airtable
+**Severity:** Low  
+**File:** `src/app/api/admin/invite-admin/route.js` lines 67–82
+
+**Root cause:**
+When an existing Staff record is found (the re-invite path), only the `Invite Nonce` is updated. The `Name` field is not written. If the original name was misspelled and the admin re-invites with the corrected name, the Airtable record retains the old name. The webhook email uses the new name from the request payload (correct), but Airtable is stale.
+
+**Proposed solution:**  
+Update `Name` when writing the nonce on re-invite:
+```js
+await base("Staff").update([{
+  id: staffId,
+  fields: {
+    Name: name.trim(),       // update name in case it changed
+    "Invite Nonce": inviteNonce,
+  }
+}])
+```
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> Read current `invite-admin/route.js` to confirm the nonce update call at ~line 90. Ensure the `name` variable is available at that point (it is, from `request.json()`).
+
+---
+
+### Bug 4 — Non-admin Staff record silently promoted to admin
+**Severity:** Low  
+**File:** `src/app/api/admin/invite-admin/route.js` line 62
+
+**Root cause:**
+The existing-record lookup queries `Staff` by `Email` only — it does not filter by `IsAdmin`. If a Staff record exists with `IsAdmin: false` (a non-admin staff member), the invite flow will find it, add an `Invite Nonce`, send an invite email, and ultimately set `IsAdmin: true` when the invite is accepted. The inviting admin receives no warning that they're upgrading an existing account.
+
+**Proposed solution:**  
+Surface a warning when the found record is not already an admin:
+```js
+if (existing.length > 0) {
+  staffId = existing[0].id
+  alreadyConfigured = Boolean(existing[0].fields?.Password)
+  const isAlreadyAdmin = Boolean(existing[0].fields?.IsAdmin)
+  if (!isAlreadyAdmin && !alreadyConfigured) {
+    // Log or return a warning — or add a flag to the response
+    logger.warn(`invite-admin: existing non-admin Staff record will be promoted`, { staffId })
+  }
+}
+```
+Alternatively, return a distinct response code/message to the frontend so the admin is shown a confirmation dialog ("This email belongs to an existing non-admin staff member. Promote them to admin?").
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> 1. Confirm the `IsAdmin` field name in Airtable matches exactly (case-sensitive). Check other routes that read this field, e.g. `src/app/api/admin/login/route.js`.  
+> 2. Decide whether this should block the invite (require explicit confirmation) or just log a warning — this is a product decision.
+
+---
+
+### Bug 5 — No token expiry feedback on page load
+**Severity:** UX  
+**File:** `src/app/accept-admin-invite/page.js` lines 25–28
+
+**Root cause:**
+The page reads the `?token=` query param and stores it in state, but does not decode or validate the JWT on mount. If the user opens an expired link (token > 24h old), they won't know until they fill in their password and submit — at which point the API returns "Invalid or expired token".
+
+**Proposed solution:**  
+Decode (not verify — no secret needed client-side) the JWT on mount to read the `exp` claim:
+```js
+useEffect(() => {
+  const t = searchParams.get("token")
+  if (!t) return
+  setToken(t)
+  try {
+    const parts = t.split(".")
+    if (parts.length === 3) {
+      const decoded = JSON.parse(atob(parts[1]))
+      if (decoded.exp && decoded.exp * 1000 < Date.now()) {
+        setError("This invite link has expired. Ask an admin to resend the invite.")
+      }
+    }
+  } catch {
+    // silently ignore decode errors — server will catch them on submit
+  }
+}, [searchParams])
+```
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> 1. Read `accept-admin-invite/page.js` in full to confirm no expiry check already exists.  
+> 2. Confirm that the `setError` state variable is used for the error display block (it is, based on current code).  
+> 3. This is a UX improvement only — the server still validates the token on submit regardless.
+
+---
+
+### Bug 6 — `name` is not trimmed before use
+**Severity:** Very Low  
+**File:** `src/app/api/admin/invite-admin/route.js` lines 32–34, 72–78
+
+**Root cause:**
+`email` is trimmed and lowercased before use, but `name` is used as-is from `request.json()`. A name with leading/trailing spaces (e.g., `"  John Smith  "`) passes the `!name` check, gets stored in Airtable with spaces, and the email template greets the user as `"Hi   John Smith  ,"`.
+
+**Proposed solution:**  
+Add `name.trim()` at the point of use:
+```js
+const normalisedName = String(name).trim()
+if (!normalisedName || !email) {
+  return Response.json({ error: "Name and email are required" }, { status: 400 })
+}
+```
+Then use `normalisedName` everywhere `name` is used (Staff record creation, webhook payload).
+
+> **⚠️ VALIDATE BEFORE IMPLEMENTING:**  
+> Read current `invite-admin/route.js` and confirm all places where `name` is used in the function body (Airtable create, webhook payload, audit log). Replace all of them.
+
+---
+
+## Bug Priority
+
+| # | Bug | Severity | Effort |
+|---|-----|----------|--------|
+| 1 | Make.com error message swallowed in 502 (webhook is sync — original async diagnosis was wrong) | Low | Trivial |
+| 2 | Orphaned Staff record on webhook failure | Medium | Small–Medium |
+| 3 | Re-invite doesn't update `Name` | Low | Trivial |
+| 4 | Non-admin Staff silently promoted | Low | Small |
+| 5 | No expiry feedback on page load | UX | Small |
+| 6 | `name` not trimmed | Very Low | Trivial |

--- a/TASK-admin-invite-workflow-audit.md
+++ b/TASK-admin-invite-workflow-audit.md
@@ -309,3 +309,101 @@ Then use `normalisedName` everywhere `name` is used (Staff record creation, webh
 | 4 | Non-admin Staff silently promoted | Low | Small |
 | 5 | No expiry feedback on page load | UX | Small |
 | 6 | `name` not trimmed | Very Low | Trivial |
+
+---
+
+## Testing
+
+### Unit tests (automated)
+
+**File:** `src/app/api/admin/invite-admin/route.test.js`
+
+Run with:
+```bash
+npm test -- invite-admin --forceExit
+```
+
+15 tests covering the route directly (no HTTP server, no live Airtable). Each bug fix has at least one dedicated test case:
+
+| Test | Bug covered |
+|------|-------------|
+| returns 400 when name is whitespace only | Bug 6 |
+| creates Staff record with trimmed name | Bug 6 |
+| sends trimmed name to Make.com webhook | Bug 6 |
+| updates Name field on re-invite | Bug 3 |
+| logs warning when inviting existing non-admin Staff record | Bug 4 |
+| returns 502 with Make.com error message when webhook fails | Bug 1 |
+| deletes newly-created Staff record when webhook fails | Bug 2 |
+| does NOT delete existing Staff record when webhook fails | Bug 2 |
+| returns 401 when no session cookie | Auth |
+| returns 403 when session role is not admin | Auth |
+| returns 400 when name is missing | Validation |
+| returns 400 when email is invalid | Validation |
+| returns 400 when user already has a password | Validation |
+| reuses existing Staff record on re-invite | Re-invite path |
+| returns 200 with staffId on success | Happy path |
+
+**Patterns and gotchas in the test file:**
+- Uses `jest.doMock()` + `jest.resetModules()` (same pattern as all other route tests in this project). All mocks must be set up via `setupMocks()` before requiring the route — re-mocking after the fact requires another `resetModules()` call.
+- `jest.resetModules()` creates new module instances, so any reference to a mocked module (e.g. `logger`) obtained *before* calling `setupMocks()` will be stale. Always call `require("@/lib/utils/logger")` *after* `setupMocks()` in tests that check logger calls.
+- `global.crypto.randomUUID` is mocked to return a fixed nonce so assertions on Airtable update calls are deterministic.
+- `global.fetch` is mocked to simulate Make.com webhook responses — set `webhookOk: false` + `webhookBody` in the overrides to simulate failures.
+
+---
+
+### Manual E2E: happy path
+
+**Prerequisites:** dev server running (`npm run dev`), valid Airtable base, Make.com scenario active and Gmail connected.
+
+1. Log in as an existing admin → go to **Profile → "Create Admin"**
+2. Enter a real email you can receive (use a personal inbox, not the sending account)
+3. Confirm in the dialog → expect toast: "Invite sent successfully"
+4. Open your inbox — expect an email from `managers@smilecliniq.com` with subject "You have been invited to join our platform as an admin!"
+5. Click "Set Your Password" (or copy the fallback URL)
+6. Set a password meeting the rules (8+ chars, special char, no `123` etc.)
+7. Expect: immediate redirect to `/admin/dashboard`, logged in automatically
+8. Check Airtable `Staff` table: `IsAdmin: true`, bcrypt hash in `Password`, **`Invite Nonce` empty**
+
+---
+
+### Manual E2E: bug-specific scenarios
+
+**Bug 1 + 2 — Webhook failure and rollback**
+1. Temporarily set `MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE` in `.env.local` to a broken URL (e.g. `https://hook.make.com/invalid`)
+2. Invite a **new** email → the toast error should include the Make.com error detail, not just "Failed to trigger invite email"
+3. Check Airtable `Staff` — the record should **not exist** (rollback worked)
+4. Invite an email that **already has a partial record** (no password) → same 502, but the record should **still exist** (no rollback for pre-existing records)
+5. Restore the correct webhook URL
+
+**Bug 3 — Name update on re-invite**
+1. Invite `test@example.com` with name `"Alice"` — let the email send but don't accept the invite
+2. Invite the same `test@example.com` again with name `"Alice Smith"`
+3. Check Airtable `Staff` — Name field should now be `"Alice Smith"` and a fresh nonce should be present (the old invite link is now invalid)
+
+**Bug 4 — Non-admin Staff promotion warning**
+1. Manually create a Staff record in Airtable with `IsAdmin: false`, a specific email, and no password
+2. Invite that email via the admin UI → invite should succeed
+3. Check the server terminal (running `npm run dev`) for a warn log containing `"promoting existing non-admin Staff record to admin"`
+4. Accept the invite → verify the record now has `IsAdmin: true`
+
+**Bug 5 — Token expiry on page load**
+1. Use an invite link from a previous test that has already been used or is older than 24h
+2. Navigate directly to `/accept-admin-invite?token=<that-token>`
+3. Expect: error message "This invite link has expired. Ask an admin to resend the invite." appears **on page load**, before typing anything
+
+**Bug 6 — Name trimming**
+1. In the invite dialog enter `"  John Smith  "` (leading and trailing spaces) as the name
+2. Send the invite
+3. Check the email received — greeting should be `"Hi John Smith,"` not `"Hi   John Smith  ,"`
+4. Check Airtable — Name field should be `"John Smith"` (no spaces)
+
+---
+
+### What is NOT covered by unit tests
+
+| Scenario | Why not in unit tests | How to verify |
+|----------|----------------------|---------------|
+| Accept-invite page token expiry display (Bug 5) | React client component — project uses `testEnvironment: node`, no jsdom | Manual Bug 5 scenario above |
+| Gmail actually delivers the email | Live external service | Manual happy path |
+| Airtable field names match the code exactly | Schema can't be validated in tests | Check `Staff` table has: `Name`, `Email`, `Password`, `IsAdmin`, `Invite Nonce` |
+| Session cookie works across redirect | Integration-level | Complete the manual happy path end-to-end |

--- a/src/app/accept-admin-invite/page.js
+++ b/src/app/accept-admin-invite/page.js
@@ -24,7 +24,22 @@ function AcceptAdminInviteInner() {
 
   useEffect(() => {
     const t = searchParams.get("token")
-    if (t) setToken(t)
+    if (!t) return
+    setToken(t)
+    // Client-side expiry pre-check: decode the JWT payload (no verification) to read exp
+    try {
+      const parts = t.split(".")
+      if (parts.length === 3) {
+        // JWT uses base64url — replace - and _ before decoding
+        const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/")
+        const decoded = JSON.parse(atob(base64))
+        if (decoded.exp && decoded.exp * 1000 < Date.now()) {
+          setError("This invite link has expired. Ask an admin to resend the invite.")
+        }
+      }
+    } catch {
+      // Silently ignore — server validation on submit will catch malformed tokens
+    }
   }, [searchParams])
 
   const handleSubmit = async (e) => {

--- a/src/app/api/admin/invite-admin/route.js
+++ b/src/app/api/admin/invite-admin/route.js
@@ -30,7 +30,8 @@ export async function POST(request) {
     }
 
     const { name, email } = await request.json()
-    if (!name || !email) {
+    const normalisedName = String(name || "").trim()
+    if (!normalisedName || !email) {
       return Response.json({ error: "Name and email are required" }, { status: 400 })
     }
 
@@ -64,14 +65,19 @@ export async function POST(request) {
 
     let staffId
     let alreadyConfigured = false
+    let createdInThisRequest = false
     if (existing.length > 0) {
       staffId = existing[0].id
       alreadyConfigured = Boolean(existing[0].fields?.Password)
+      // Warn if promoting an existing non-admin staff record to admin
+      if (!alreadyConfigured && !existing[0].fields?.IsAdmin) {
+        logger.warn("invite-admin: promoting existing non-admin Staff record to admin", { staffId, email: normalisedEmail })
+      }
     } else {
       const created = await base("Staff").create([
         {
           fields: {
-            Name: name,
+            Name: normalisedName,
             Email: normalisedEmail,
             IsAdmin: true,
             Password: "", // pending until invite accepted
@@ -79,6 +85,7 @@ export async function POST(request) {
         },
       ])
       staffId = created[0].id
+      createdInThisRequest = true
     }
 
     if (alreadyConfigured) {
@@ -89,7 +96,10 @@ export async function POST(request) {
     const inviteNonce = crypto.randomUUID()
     await base("Staff").update([{
       id: staffId,
-      fields: { "Invite Nonce": inviteNonce }
+      fields: {
+        Name: normalisedName, // keep Name current on re-invite
+        "Invite Nonce": inviteNonce,
+      },
     }])
 
     // Create 24h invite token
@@ -109,7 +119,7 @@ export async function POST(request) {
 
     // Notify via Make.com webhook
     const payload = {
-      name,
+      name: normalisedName,
       email: normalisedEmail,
       inviteLink,
       requestedBy: requesterEmail,
@@ -121,10 +131,17 @@ export async function POST(request) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     })
+    const webhookBody = await webhookRes.json().catch(() => null)
     if (!webhookRes.ok) {
-      const text = await webhookRes.text()
-      logger.error("Admin invite webhook failed", { status: webhookRes.status, text })
-      return Response.json({ error: "Failed to trigger invite email" }, { status: 502 })
+      const makeError = webhookBody?.error || "Unknown error"
+      logger.error("Admin invite webhook failed", { status: webhookRes.status, body: webhookBody })
+      // Rollback: remove the Staff record if we just created it so Airtable stays clean
+      if (createdInThisRequest) {
+        await base("Staff").destroy([staffId]).catch((e) =>
+          logger.error("Failed to rollback Staff record after webhook failure", { staffId, error: e.message })
+        )
+      }
+      return Response.json({ error: `Failed to trigger invite email: ${makeError}` }, { status: 502 })
     }
 
     try {

--- a/src/app/api/admin/invite-admin/route.test.js
+++ b/src/app/api/admin/invite-admin/route.test.js
@@ -1,0 +1,257 @@
+import { jest } from "@jest/globals";
+
+jest.mock("@/lib/utils/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+}));
+jest.mock("@/lib/auditLogger", () => ({
+  logAuditEvent: jest.fn(),
+}));
+
+class TestResponse {
+  constructor(data, status = 200) {
+    this._data = data;
+    this.status = status;
+  }
+  async json() { return this._data; }
+}
+global.Response = {
+  json: (data, options = {}) => new TestResponse(data, options.status || 200),
+};
+
+const makeRequest = (body) => ({ json: jest.fn().mockResolvedValue(body) });
+
+// ─── shared default mock values ──────────────────────────────────────────────
+
+const ADMIN_SESSION = { userEmail: "admin@example.com", userRole: "admin", userName: "Admin" };
+const EXISTING_ADMIN_RECORD = { id: "staff_existing", fields: { Email: "invited@example.com", Password: "", IsAdmin: true } };
+const EXISTING_NON_ADMIN_RECORD = { id: "staff_nonadmin", fields: { Email: "staff@example.com", Password: "", IsAdmin: false } };
+const NEW_RECORD_ID = "staff_new_123";
+const NONCE = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const JWT_TOKEN = "header.payload.signature";
+
+// ─── setup helper ────────────────────────────────────────────────────────────
+
+const setupMocks = (overrides = {}) => {
+  jest.resetModules();
+
+  // env vars
+  process.env.AIRTABLE_API_KEY = "test_key";
+  process.env.AIRTABLE_BASE_ID = "test_base";
+  process.env.JWT_SECRET = "test_jwt_secret";
+  process.env.MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE = "https://hook.make.com/test";
+  process.env.NODE_ENV = "test";
+  process.env.APP_BASE_URL = "https://app.smilecliniq.com";
+
+  // crypto.randomUUID
+  global.crypto = { randomUUID: jest.fn().mockReturnValue(NONCE) };
+
+  // fetch (Make.com webhook)
+  const webhookOk = overrides.webhookOk !== undefined ? overrides.webhookOk : true;
+  const webhookBody = overrides.webhookBody !== undefined
+    ? overrides.webhookBody
+    : { success: true, messageId: "msg_123" };
+  global.fetch = overrides.fetch || jest.fn().mockResolvedValue({
+    ok: webhookOk,
+    json: jest.fn().mockResolvedValue(webhookBody),
+  });
+
+  // iron-session
+  jest.doMock("iron-session", () => ({
+    unsealData: jest.fn().mockResolvedValue(overrides.session ?? ADMIN_SESSION),
+  }));
+
+  // next/headers cookies — allow callers to override the get() return value
+  const cookiesGetMock = overrides.cookiesGet ?? jest.fn().mockReturnValue({ value: "sealed_session" });
+  jest.doMock("next/headers", () => ({
+    cookies: jest.fn().mockReturnValue({ get: cookiesGetMock, set: jest.fn() }),
+  }));
+
+  // jsonwebtoken
+  jest.doMock("jsonwebtoken", () => ({
+    sign: jest.fn().mockReturnValue(JWT_TOKEN),
+  }));
+
+  // Airtable operations
+  const selectFirstPage = overrides.selectFirstPage ?? jest.fn().mockResolvedValue([]);
+  const staffCreate = overrides.staffCreate ?? jest.fn().mockResolvedValue([{ id: NEW_RECORD_ID }]);
+  const staffUpdate = overrides.staffUpdate ?? jest.fn().mockResolvedValue([]);
+  const staffDestroy = overrides.staffDestroy ?? jest.fn().mockResolvedValue([]);
+
+  jest.doMock("airtable", () =>
+    jest.fn().mockImplementation(() => ({
+      base: jest.fn().mockImplementation(() => (tableName) => {
+        if (tableName === "Staff") {
+          return {
+            select: jest.fn().mockReturnValue({ firstPage: selectFirstPage }),
+            create: staffCreate,
+            update: staffUpdate,
+            destroy: staffDestroy,
+          };
+        }
+        return {};
+      }),
+    }))
+  );
+
+  const { POST } = require("./route");
+  return { POST, staffCreate, staffUpdate, staffDestroy, selectFirstPage };
+};
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/invite-admin", () => {
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  test("returns 401 when no session cookie", async () => {
+    // Pass the no-cookie override directly so setupMocks loads the route with it
+    const { POST } = setupMocks({ cookiesGet: jest.fn().mockReturnValue(undefined) });
+    const res = await POST(makeRequest({ name: "Alice", email: "alice@example.com" }));
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 when session role is not admin", async () => {
+    const { POST } = setupMocks({ session: { userEmail: "user@example.com", userRole: "user" } });
+    const res = await POST(makeRequest({ name: "Alice", email: "alice@example.com" }));
+    expect(res.status).toBe(403);
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  test("returns 400 when name is missing", async () => {
+    const { POST } = setupMocks();
+    const res = await POST(makeRequest({ email: "alice@example.com" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/name/i);
+  });
+
+  // Bug 6: whitespace-only name must be rejected
+  test("returns 400 when name is whitespace only", async () => {
+    const { POST } = setupMocks();
+    const res = await POST(makeRequest({ name: "   ", email: "alice@example.com" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/name/i);
+  });
+
+  test("returns 400 when email is invalid", async () => {
+    const { POST } = setupMocks();
+    const res = await POST(makeRequest({ name: "Alice", email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/email/i);
+  });
+
+  test("returns 400 when user already has a password (already configured)", async () => {
+    const { POST } = setupMocks({
+      selectFirstPage: jest.fn().mockResolvedValue([{
+        id: "staff_1",
+        fields: { Email: "existing@example.com", Password: "hashed_pw", IsAdmin: true },
+      }]),
+    });
+    const res = await POST(makeRequest({ name: "Existing", email: "existing@example.com" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/already has an admin account/i);
+  });
+
+  // ── Happy path: new invite ─────────────────────────────────────────────────
+
+  test("creates Staff record with trimmed name for a new email", async () => {
+    const { POST, staffCreate } = setupMocks();
+    const res = await POST(makeRequest({ name: "  Alice  ", email: "alice@example.com" }));
+    expect(res.status).toBe(200);
+    expect(staffCreate).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fields: expect.objectContaining({ Name: "Alice", Email: "alice@example.com" }),
+      }),
+    ]);
+  });
+
+  test("sends trimmed name to Make.com webhook", async () => {
+    const { POST } = setupMocks();
+    await POST(makeRequest({ name: "  Alice  ", email: "alice@example.com" }));
+    const [, options] = global.fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.name).toBe("Alice");
+  });
+
+  test("returns 200 with staffId on success", async () => {
+    const { POST } = setupMocks();
+    const res = await POST(makeRequest({ name: "Alice", email: "alice@example.com" }));
+    expect(res.status).toBe(200);
+    expect((await res.json())).toMatchObject({ message: "Invite sent", staffId: NEW_RECORD_ID });
+  });
+
+  // ── Re-invite (existing record, no password) ──────────────────────────────
+
+  test("reuses existing Staff record on re-invite", async () => {
+    const { POST, staffCreate } = setupMocks({
+      selectFirstPage: jest.fn().mockResolvedValue([EXISTING_ADMIN_RECORD]),
+    });
+    const res = await POST(makeRequest({ name: "Alice Updated", email: "invited@example.com" }));
+    expect(res.status).toBe(200);
+    expect(staffCreate).not.toHaveBeenCalled();
+  });
+
+  // Bug 3: re-invite must update the Name field
+  test("updates Name field on re-invite", async () => {
+    const { POST, staffUpdate } = setupMocks({
+      selectFirstPage: jest.fn().mockResolvedValue([EXISTING_ADMIN_RECORD]),
+    });
+    await POST(makeRequest({ name: "Alice Updated", email: "invited@example.com" }));
+    expect(staffUpdate).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fields: expect.objectContaining({ Name: "Alice Updated" }),
+      }),
+    ]);
+  });
+
+  // Bug 4: warn when promoting a non-admin Staff record
+  test("logs warning when inviting an existing non-admin Staff record", async () => {
+    const { POST } = setupMocks({
+      selectFirstPage: jest.fn().mockResolvedValue([EXISTING_NON_ADMIN_RECORD]),
+    });
+    // Require logger AFTER setupMocks so we get the same instance the route uses
+    const logger = require("@/lib/utils/logger");
+    await POST(makeRequest({ name: "Staff Member", email: "staff@example.com" }));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("promoting existing non-admin"),
+      expect.any(Object)
+    );
+  });
+
+  // ── Webhook failure handling ──────────────────────────────────────────────
+
+  // Bug 1 (revised): Make.com error body surfaced in 502
+  test("returns 502 with Make.com error message when webhook fails", async () => {
+    const { POST } = setupMocks({
+      webhookOk: false,
+      webhookBody: { success: false, error: "Gmail authentication failed" },
+    });
+    const res = await POST(makeRequest({ name: "Alice", email: "alice@example.com" }));
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toContain("Gmail authentication failed");
+  });
+
+  // Bug 2: rollback newly-created record when webhook fails
+  test("deletes newly-created Staff record when webhook fails", async () => {
+    const { POST, staffDestroy } = setupMocks({
+      webhookOk: false,
+      webhookBody: { success: false, error: "Gmail error" },
+    });
+    await POST(makeRequest({ name: "Alice", email: "alice@example.com" }));
+    expect(staffDestroy).toHaveBeenCalledWith([NEW_RECORD_ID]);
+  });
+
+  // Bug 2: existing record must NOT be deleted on webhook failure
+  test("does NOT delete existing Staff record when webhook fails", async () => {
+    const { POST, staffDestroy } = setupMocks({
+      selectFirstPage: jest.fn().mockResolvedValue([EXISTING_ADMIN_RECORD]),
+      webhookOk: false,
+      webhookBody: { success: false, error: "Gmail error" },
+    });
+    await POST(makeRequest({ name: "Alice", email: "invited@example.com" }));
+    expect(staffDestroy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug 1** — Parse Make.com JSON error body and surface the actual error message in the 502 response (previously swallowed as a generic string)
- **Bug 2** — Rollback newly-created `Staff` record in Airtable if the Make.com webhook fails, keeping the table clean; existing records are left untouched
- **Bug 3** — Update the `Name` field on re-invite so Airtable stays current if the name changed since the first invite
- **Bug 4** — Log a warning when an existing non-admin `Staff` record is being promoted to admin via the invite flow
- **Bug 5** — Decode the JWT payload client-side on page load to show a token expiry error immediately, rather than only after the user fills in and submits the form
- **Bug 6** — Trim `name` input before use; whitespace-only names now fail validation

Full workflow documentation and bug analysis: `TASK-admin-invite-workflow-audit.md`

## Test plan

- [ ] `npm test -- invite-admin --forceExit` — 15 unit tests, all passing (covers bugs 1–4, 6)
- [ ] Manual happy path: invite a real email, receive email, set password, confirm redirect to `/admin/dashboard` and auto-login
- [ ] **Bug 2:** Set `MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE` to a broken URL, invite a new email → confirm 502 with error detail, confirm no orphaned record in Airtable `Staff`
- [ ] **Bug 3:** Invite the same email twice with different names → confirm Airtable `Name` field reflects the second invite
- [ ] **Bug 4:** Pre-create a `Staff` record with `IsAdmin: false`, invite that email → confirm server warn log appears
- [ ] **Bug 5:** Navigate to `/accept-admin-invite?token=<expired-token>` → confirm expiry message appears on load, no form submission needed
- [ ] **Bug 6:** Submit invite with `"  John Smith  "` as name → confirm email greets `"Hi John Smith,"` and Airtable stores `"John Smith"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)