### PR TITLE
feat: role-based quiz assignment

### DIFF
--- a/TASK-role-based-quiz-assignment.md
+++ b/TASK-role-based-quiz-assignment.md
@@ -1,0 +1,187 @@
+# TASK: Role-Based Quiz Assignment
+
+**Branch**: `feat/role-based-quiz-assignment`
+**Status**: In Progress
+
+## Problem
+
+The client reports "everyone is getting the quiz" — nurses and receptionists both see every quiz regardless of their job role. Root causes:
+1. `Onboarding Quizzes` Airtable table has **no `Target Roles` field**
+2. `/api/user/quizzes` (GET) fetches ALL task-log-linked quizzes with zero role filtering
+3. No bulk-assign-by-role workflow — admins assign per-individual, often to everyone
+
+## Client Question Answered
+
+> "How do we assign different quizzes for nurses and receptionists according to roles?"
+
+After this fix, the workflow will be:
+1. Admin creates a quiz → sets `Target Roles = ["Dental Nurse"]`
+2. Admin clicks "Assign to Roles" → system auto-creates task logs for all Dental Nurses
+3. When a Dental Nurse logs in, they see only their quizzes. A Receptionist does NOT see nurse quizzes — the server-side role filter blocks it even if accidentally assigned.
+
+## Pre-requisite (Client Must Do This in Airtable)
+
+In the `Onboarding Quizzes` Airtable table, add:
+- **Field name**: `Target Roles`
+- **Field type**: Multi-select
+- **Options**: `Dental Nurse`, `Receptionist`, `Dentist` (add more roles as needed)
+- **Leave blank** = quiz applies to ALL roles (backward compatible with existing quizzes)
+
+> **Implementation cannot be fully tested until the client makes this Airtable change.**
+
+## Key Architecture Context
+
+- `Applicants` table → `Job Name` field (text): `"Dental Nurse"`, `"Receptionist"`, `"Dentist"`
+- `Onboarding Quizzes` table → currently no role field (adding `Target Roles`)
+- `Onboarding Tasks Logs` table → links applicants to quiz tasks via `Assigned` and `Onboarding Quizzes` fields; also has `Applicant Job` (text) field
+- `/api/user/quizzes` only checks `FIND(email, ARRAYJOIN({Assigned}))` — no role check at all
+
+Reuse patterns:
+- Task log creation: `src/app/api/admin/tasks/create-task/route.js` lines 137–228
+- Airtable FIND formula for job: `core-tasks/route.js` line 97
+- Airtable chunk creates (10 per request): `quizzes/route.js` lines 117–120
+
+## Sub-tasks
+
+- [x] **Step 0** — Create branch + this TASK doc
+- [x] **Step 1** — `src/app/api/admin/quizzes/route.js`: Add `Target Roles` to GET list + POST create
+- [x] **Step 2** — `src/app/api/admin/quizzes/[quizId]/route.js`: Add `Target Roles` to PUT update
+- [x] **Step 3** — `src/app/api/user/quizzes/route.js`: Refactor `getApplicantIdByEmail` to return `jobName`, add role filter gate
+- [x] **Step 4** — Create `src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js` (new file)
+- [x] **Step 5** — `src/app/admin/quizzes/page.js`: Add `KNOWN_ROLES`, Target Role select in create/edit dialogs, role badge in list, Bulk Assign button
+
+---
+
+## Detailed Implementation
+
+### Step 1 — `src/app/api/admin/quizzes/route.js`
+
+**GET** (line 23–25): Add `"Target Roles"` to `fields` array. In `map()` after line 32:
+```js
+targetRoles: r.get("Target Roles") || []
+```
+
+**POST** (line 52): Add `targetRoles` to destructure. In `quizFields` object (after line 91):
+```js
+if (Array.isArray(targetRoles) && targetRoles.length > 0) {
+  quizFields["Target Roles"] = targetRoles
+}
+```
+
+Commit: `feat: read and write Target Roles field on quiz create/list`
+
+---
+
+### Step 2 — `src/app/api/admin/quizzes/[quizId]/route.js`
+
+In `PUT` handler patch section (after line 24):
+```js
+if (Array.isArray(body.targetRoles)) patch["Target Roles"] = body.targetRoles
+```
+Note: allow empty array `[]` to clear/reset roles.
+
+Commit: `feat: allow updating Target Roles on quiz edit`
+
+---
+
+### Step 3 — `src/app/api/user/quizzes/route.js` ← CORE FIX
+
+**a)** Rename `getApplicantIdByEmail` → `getApplicantRecord`, return `{ id, jobName }`:
+```js
+async function getApplicantRecord(userEmail) {
+  const applicants = await base(APPLICANTS)
+    .select({ filterByFormula: `{Email} = '${userEmail}'`, maxRecords: 1, fields: ['Job Name'] })
+    .firstPage()
+  return { id: applicants[0]?.id, jobName: applicants[0]?.fields?.['Job Name'] || null }
+}
+```
+
+**b)** Line 33: `const { id: applicantId, jobName: userJobName } = await getApplicantRecord(user.userEmail)`
+
+**c)** After line 91 (after `quizRec` fetched, before submissions check), add:
+```js
+const targetRoles = quizRec.get("Target Roles") || []
+if (targetRoles.length > 0 && userJobName && !targetRoles.includes(userJobName)) {
+  return null // role mismatch
+}
+```
+
+Commit: `fix: filter user quizzes by job role to prevent cross-role visibility`
+
+---
+
+### Step 4 — NEW: `src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js`
+
+New `POST` handler:
+1. Validate admin session (copy from `route.js` lines 9–16)
+2. Parse `{ roles }` from body; if empty, fetch quiz `Target Roles` from Airtable
+3. Build OR formula for role matching:
+   ```js
+   const roleConditions = roles.map(r => `FIND('${r}', {Job Name}) > 0`).join(', ')
+   const formula = roles.length === 1 ? roleConditions : `OR(${roleConditions})`
+   ```
+4. Query `Applicants` with that formula, fields: `['Job Name', 'Email']`
+5. For each applicant, check for existing task log (avoid duplicates):
+   ```
+   AND(FIND('${applicantId}', ARRAYJOIN({Assigned})), FIND('${quizId}', ARRAYJOIN({Onboarding Quizzes})))
+   ```
+6. Collect applicants without existing logs → batch create `Onboarding Tasks Logs` records (10 per chunk):
+   ```js
+   { fields: { "Assigned": [applicant.id], "Onboarding Quizzes": [quizId], "Status": "Assigned", "Applicant Job": applicant.fields["Job Name"] || "" } }
+   ```
+7. Return `{ created: N, skipped: N, roles }`
+
+Commit: `feat: add bulk-assign-by-role API endpoint for quizzes`
+
+---
+
+### Step 5 — `src/app/admin/quizzes/page.js`
+
+**a)** Above component (line 30), add:
+```js
+const KNOWN_ROLES = ["Dental Nurse", "Receptionist", "Dentist"]
+```
+
+**b)** `createQuiz` state (line 140): add `targetRoles: []`
+
+**c)** Create dialog: Below the Week `<Input>`, add a labeled checkbox group using existing `<Checkbox>` + `<Label>` imports (already at line 25). Toggle roles in `createQuiz.targetRoles`. Pass `targetRoles: createQuiz.targetRoles` in POST body.
+
+**d)** Edit state in `openEdit` (line 173): add `targetRoles: quiz.targetRoles || []`. Add same checkbox group in edit dialog. Include in PUT body.
+
+**e)** Quiz list: display `<Badge>` per role (import already at line 14). If empty, show `<Badge variant="secondary">All Roles</Badge>`.
+
+**f)** Per quiz card, add "Assign to Roles" `<Button>`:
+```js
+onClick={async () => {
+  const res = await fetch(`/api/admin/quizzes/${quiz.id}/bulk-assign`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ roles: quiz.targetRoles })
+  })
+  const data = await res.json()
+  if (res.ok) toast.success(`Assigned ${data.created} applicant(s) — ${data.skipped} already assigned`)
+  else toast.error("Bulk assignment failed")
+}}
+```
+
+Commit: `feat: add Target Roles UI and bulk-assign button to admin quiz management`
+
+---
+
+## Verification Checklist
+
+- [ ] Airtable: `Target Roles` multi-select field exists in `Onboarding Quizzes`
+- [ ] `npm run dev` → `/admin/quizzes?tab=quizzes`
+- [ ] Create quiz with `Target Roles = ["Dental Nurse"]` → verify field set in Airtable
+- [ ] Edit quiz, add/remove roles → verify Airtable field updates
+- [ ] Dental Nurse applicant login → `/api/user/quizzes` returns nurse quiz
+- [ ] Receptionist applicant login → nurse quiz does NOT appear
+- [ ] Quiz with empty `Target Roles` → visible to ALL roles
+- [ ] "Assign to Roles" button → Airtable shows new task logs only for matching-role applicants
+- [ ] Re-click "Assign to Roles" → no duplicate task logs created
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes
+
+## Other Bugs Noted (Do NOT fix in this branch)
+
+1. **Localhost agent logging in production**: `fetch('http://127.0.0.1:7242/ingest/...')` in `quizzes/route.js` line 124 and `[quizId]/route.js` line 80
+2. **Quiz item delete formula**: `route.js` DELETE uses `{Quiz ID}` (line 61) — verify this matches actual Airtable field name `Quiz Link` or items won't be deleted

--- a/docs/admin-quizzes.md
+++ b/docs/admin-quizzes.md
@@ -65,9 +65,10 @@ Notes:
 - For now, we return one page (`pageSize` default 50). Advanced pagination can be added later.
 
 ### Airtable schema
-- Onboarding Quizzes: `Quiz Title`, `Passing Score`, `Week`, links to `Onboarding Quiz Questions` and `Submissions`.
+- Onboarding Quizzes: `Quiz Title`, `Passing Score`, `Week`, `Target Roles` (singleSelect, field ID `fldSHMGQGWUxecF65`), links to `Onboarding Quiz Questions` and `Submissions`.
 - Onboarding Quiz Items: `Type`, `Q.Type` (Radio/Checkbox), `Content`, `Options` (multiline string, `<br>`-joined), `Correct Answer`, `Order`, `Points`, link to quiz.
 - Onboarding Quiz Submissions: `Quiz Title` (formula), `Passed?`, `Score`, `Total Form Score`, `Submission Timestamp`, `Respondent Email`, links to `Applicants` and `Onboarding - Quizzes`, `Answers` (JSON string).
+- Applicants: `Job Name` (multipleLookupValues via field `fldd0RHjePJFSOoQP`, returns array — take `[0]` for the role string).
 
 ### Options field handling
 - Airtable `Options` is stored as a multiline string joined by `<br>` (HTML). In some cases, values can be HTML-escaped: `&lt;br>`.
@@ -80,25 +81,53 @@ Rules:
 - Radio: Correct Answer must be exactly one of the options.
 - Checkbox: Correct Answer may represent multiple options (stored either as `<br>`-joined string or array); each must match an option.
 
+### Role-Based Quiz Assignment
+
+Quizzes can be targeted to specific job roles so applicants only see quizzes relevant to their position.
+
+#### How it works
+
+1. Each quiz has an optional `Target Roles` field (Airtable singleSelect: `Nurse`, `Receptionist`, `Dentist`).
+2. When set, the field acts as a server-side gate in `/api/user/quizzes` — applicants whose `Job Name` doesn't match the target role will not see the quiz, even if a task log exists for them.
+3. A quiz with no `Target Roles` set is visible to all roles (backward compatible).
+
+#### Admin workflow
+
+1. **Create** a quiz and select a **Target Role** from the dropdown (or leave as “All roles”).
+2. Click **Assign** on the quiz card — the system finds all applicants in Airtable with a matching `Job Name` and creates `Onboarding Tasks Logs` records for those not already assigned. Duplicate assignments are skipped.
+3. The quiz card displays a badge showing the target role (or “All Roles”).
+
+#### Role values
+
+Must match exactly what is stored in `Applicants.Job Name`:
+- `Nurse`
+- `Receptionist`
+- `Dentist`
+
+To add new roles, update the `KNOWN_ROLES` constant in `src/app/admin/quizzes/page.js` and the `VALID_ROLES` constant in both `src/app/api/admin/quizzes/route.js` and `src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js`, then add the matching option to the `Target Roles` singleSelect field in Airtable.
+
 ### Current state
 - Subtle “View all” link added in Applicant Drawer.
 - Quizzes Admin includes Submissions and Quizzes tabs.
 - Submissions endpoint implemented for filtering; returns `submissions` and `questionsById`.
-- Quizzes tab lists quizzes (title, passing score) with an Edit workflow:
-  - Edit modal with Page Title, Passing Score
+- Quizzes tab lists quizzes (title, passing score, target role badge) with an Edit workflow:
+  - Edit modal with Page Title, Passing Score, Target Role
   - Items editor with Type, Q.Type, Content, Order, Points
   - Options editor (list UI) and correct-answer pickers
   - Duplicate Order detection and auto-resequence dialog
   - Preview modal mirroring end-user layout
+  - Assign button for bulk-assigning to matching applicants
 
 ### Roadmap
 - Add analytics (pass rate, average score, item difficulty) and CSV export.
 - Pagination for submissions and quizzes.
 
 ### API contracts (editor)
-- GET `/api/admin/quizzes` → `{ quizzes: [{ id, title, passingScore, pageTitle }] }`
+- GET `/api/admin/quizzes` → `{ quizzes: [{ id, title, passingScore, pageTitle, targetRole }] }`
 - GET `/api/admin/quizzes/:quizId/items` → `{ items: [{ id, type, qType, content, options, correctAnswer, order, points }] }`
-- PUT `/api/admin/quizzes/:quizId` body: `{ pageTitle?, passingScore? }`
+- POST `/api/admin/quizzes` body: `{ title, pageTitle, passingScore, week, items, targetRole? }`
+- PUT `/api/admin/quizzes/:quizId` body: `{ pageTitle?, passingScore?, targetRole? }` — pass `null` to clear
+- POST `/api/admin/quizzes/:quizId/bulk-assign` body: `{ roles?: string[] }` — if omitted, uses quiz's own Target Roles → `{ created, skipped, roles }`
 - PUT `/api/admin/quizzes/items/:itemId` body: `{ type?, qType?, content?, options: string[]|string, correctAnswer?, order?, points? }`
 - POST `/api/admin/quizzes/items/batch` body: `{ items: [{ id, order }, ...] }` (resequence)
 

--- a/src/app/admin/quizzes/page.js
+++ b/src/app/admin/quizzes/page.js
@@ -27,6 +27,8 @@ import { Label } from "@components/ui/label"
 import { Textarea } from "@components/ui/textarea"
 import { toast } from "sonner"
 
+const KNOWN_ROLES = ["Nurse", "Receptionist", "Dentist"]
+
 function AdminQuizzesPageContent() {
   const params = useSearchParams()
   const router = useRouter()
@@ -137,7 +139,8 @@ function AdminQuizzesPageContent() {
 
   // Create quiz state
   const [createOpen, setCreateOpen] = useState(false)
-  const [createQuiz, setCreateQuiz] = useState({ title: "", pageTitle: "", passingScore: "", week: "" })
+  const [createQuiz, setCreateQuiz] = useState({ title: "", pageTitle: "", passingScore: "", week: "", targetRole: null })
+  const [bulkAssigning, setBulkAssigning] = useState(new Set())
   const [createItems, setCreateItems] = useState([])
   const [createSaving, setCreateSaving] = useState(false)
   const [createPreviewOpen, setCreatePreviewOpen] = useState(false)
@@ -175,7 +178,8 @@ function AdminQuizzesPageContent() {
       title: quiz.title,
       pageTitle: quiz.pageTitle || "",
       // Normalize to percent number string for editing (e.g., 60 instead of 0.6)
-      passingScore: toPercentDisplay(quiz.passingScore)
+      passingScore: toPercentDisplay(quiz.passingScore),
+      targetRole: quiz.targetRole || null
     })
     setEditQuizDirty(false)
     setEditItems([])
@@ -352,7 +356,8 @@ function AdminQuizzesPageContent() {
           pageTitle: createQuiz.pageTitle.trim(),
           passingScore: normalizedPassing,
           week: Number(createQuiz.week),
-          items: itemsPayload
+          items: itemsPayload,
+          targetRole: createQuiz.targetRole || null
         })
       })
       if (!res.ok) return false
@@ -416,13 +421,14 @@ function AdminQuizzesPageContent() {
       const originalPassingDisplay = toPercentDisplay(editOriginal.quiz?.passingScore)
       const changedQuiz =
         (editQuiz.pageTitle !== (editOriginal.quiz?.pageTitle || "")) ||
-        (String(editQuiz.passingScore ?? "") !== String(originalPassingDisplay))
+        (String(editQuiz.passingScore ?? "") !== String(originalPassingDisplay)) ||
+        (editQuiz.targetRole !== (editOriginal.quiz?.targetRole || null))
       if (changedQuiz) {
         const normalizedPassing = fromPercentInput(editQuiz.passingScore)
         await fetch(`/api/admin/quizzes/${editQuiz.id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ pageTitle: editQuiz.pageTitle, passingScore: normalizedPassing })
+          body: JSON.stringify({ pageTitle: editQuiz.pageTitle, passingScore: normalizedPassing, targetRole: editQuiz.targetRole ?? null })
         })
       }
       // Save dirty items (update existing, create new)
@@ -812,8 +818,37 @@ function AdminQuizzesPageContent() {
                       Passing Score: {formatPassingScoreLabel(q.passingScore)}
                       {q.week != null && <span className="ml-2">· Week {q.week}</span>}
                     </div>
+                    <div className="mt-1.5">
+                      <Badge variant={q.targetRole ? "secondary" : "outline"} className="text-xs">
+                        {q.targetRole || "All Roles"}
+                      </Badge>
+                    </div>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-8 px-2 text-xs"
+                      disabled={bulkAssigning.has(q.id)}
+                      title={q.targetRole ? `Assign to all ${q.targetRole}s` : "Set a Target Role before bulk assigning"}
+                      onClick={async () => {
+                        if (!q.targetRole) { toast.error("Set a Target Role on this quiz before bulk assigning"); return }
+                        setBulkAssigning(s => new Set(s).add(q.id))
+                        try {
+                          const res = await fetch(`/api/admin/quizzes/${q.id}/bulk-assign`, {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ roles: [q.targetRole] })
+                          })
+                          const data = await res.json()
+                          if (res.ok) toast.success(`Assigned to ${data.created} applicant(s) — ${data.skipped} already assigned`)
+                          else toast.error(data.error || "Bulk assignment failed")
+                        } catch { toast.error("Bulk assignment failed") }
+                        finally { setBulkAssigning(s => { const n = new Set(s); n.delete(q.id); return n }) }
+                      }}
+                    >
+                      {bulkAssigning.has(q.id) ? <Loader2 className="h-3 w-3 animate-spin" /> : "Assign"}
+                    </Button>
                     <Button size="sm" className="h-8" onClick={() => openEdit(q)}>Edit</Button>
                     <Button
                       size="sm"
@@ -926,6 +961,21 @@ function AdminQuizzesPageContent() {
                     />
                     <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-muted-foreground text-sm">%</span>
                   </div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground mb-1">Target Role</div>
+                  <Select
+                    value={editQuiz.targetRole || "all"}
+                    onValueChange={(v) => { setEditQuiz((q) => ({ ...q, targetRole: v === "all" ? null : v })); setEditQuizDirty(true) }}
+                  >
+                    <SelectTrigger className="h-9">
+                      <SelectValue placeholder="All roles" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All roles</SelectItem>
+                      {KNOWN_ROLES.map(r => <SelectItem key={r} value={r}>{r}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
 
@@ -1376,6 +1426,21 @@ function AdminQuizzesPageContent() {
                   ))}
                 </div>
               </div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Target Role</div>
+              <Select
+                value={createQuiz.targetRole || "all"}
+                onValueChange={(v) => setCreateQuiz(q => ({ ...q, targetRole: v === "all" ? null : v }))}
+              >
+                <SelectTrigger className="h-9">
+                  <SelectValue placeholder="All roles" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All roles</SelectItem>
+                  {KNOWN_ROLES.map(r => <SelectItem key={r} value={r}>{r}</SelectItem>)}
+                </SelectContent>
+              </Select>
             </div>
 
             <Separator />

--- a/src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js
+++ b/src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js
@@ -1,0 +1,127 @@
+import { cookies } from "next/headers"
+import { unsealData } from "iron-session"
+import Airtable from "airtable"
+import { logAuditEvent } from "@/lib/auditLogger"
+
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID)
+
+const VALID_ROLES = ["Nurse", "Receptionist", "Dentist"]
+
+async function getAdminSession() {
+  const cookieStore = await cookies()
+  const sealedSession = cookieStore.get("session")?.value
+  if (!sealedSession) return null
+  const session = await unsealData(sealedSession, { password: process.env.SESSION_SECRET })
+  if (!session || session.userRole !== "admin") return null
+  return session
+}
+
+export async function POST(request, { params }) {
+  let userEmail, userRole, userName
+
+  try {
+    const session = await getAdminSession()
+    if (!session) return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { "Content-Type": "application/json" } })
+
+    userEmail = session.userEmail
+    userRole = session.userRole
+    userName = session.userName || userEmail?.split("@")[0]
+
+    const { quizId } = await params
+    if (!quizId) return new Response(JSON.stringify({ error: "quizId required" }), { status: 400, headers: { "Content-Type": "application/json" } })
+
+    const body = await request.json().catch(() => ({}))
+    let roles = Array.isArray(body.roles) ? body.roles.filter(r => VALID_ROLES.includes(r)) : []
+
+    // If no roles provided in body, fall back to the quiz's own Target Roles field
+    if (roles.length === 0) {
+      const quizRec = await base("Onboarding Quizzes").find(quizId)
+      const targetRole = quizRec.get("Target Roles") || null
+      if (targetRole) roles = [targetRole]
+    }
+
+    if (roles.length === 0) {
+      return new Response(JSON.stringify({ error: "No valid roles provided and quiz has no Target Roles set" }), { status: 400, headers: { "Content-Type": "application/json" } })
+    }
+
+    // Build formula to find applicants matching any of the target roles
+    // Job Name (fldd0RHjePJFSOoQP) is a lookup field — use field name in formula
+    const roleConditions = roles.map(r => `{Job Name} = '${r}'`).join(", ")
+    const roleFormula = roles.length === 1 ? roleConditions : `OR(${roleConditions})`
+
+    const applicants = await base("Applicants")
+      .select({
+        filterByFormula: roleFormula,
+        fields: ["Email", "fldd0RHjePJFSOoQP"],
+      })
+      .all()
+
+    if (applicants.length === 0) {
+      return new Response(JSON.stringify({ created: 0, skipped: 0, roles, message: "No applicants found for the given roles" }), { status: 200, headers: { "Content-Type": "application/json" } })
+    }
+
+    // Check which applicants already have a task log for this quiz (avoid duplicates)
+    const applicantIds = applicants.map(a => a.id)
+    const existingLogs = await base("Onboarding Tasks Logs")
+      .select({
+        filterByFormula: `AND(FIND('${quizId}', ARRAYJOIN({Onboarding Quizzes})), OR(${applicantIds.map(id => `FIND('${id}', ARRAYJOIN({Assigned}))`).join(", ")}))`,
+        fields: ["Assigned"],
+      })
+      .all()
+
+    const alreadyAssignedIds = new Set(
+      existingLogs.flatMap(log => log.get("Assigned") || [])
+    )
+
+    const toAssign = applicants.filter(a => !alreadyAssignedIds.has(a.id))
+
+    if (toAssign.length === 0) {
+      return new Response(JSON.stringify({ created: 0, skipped: applicants.length, roles }), { status: 200, headers: { "Content-Type": "application/json" } })
+    }
+
+    // Create task log records in chunks of 10 (Airtable limit)
+    const records = toAssign.map(applicant => {
+      const jobNameField = applicant.get("Job Name")
+      const jobName = Array.isArray(jobNameField) ? jobNameField[0] || "" : jobNameField || ""
+      return {
+        fields: {
+          "Assigned": [applicant.id],
+          "Onboarding Quizzes": [quizId],
+          "Status": "Assigned",
+          "Applicant Job": jobName,
+        }
+      }
+    })
+
+    const chunkSize = 10
+    for (let i = 0; i < records.length; i += chunkSize) {
+      await base("Onboarding Tasks Logs").create(records.slice(i, i + chunkSize))
+    }
+
+    await logAuditEvent({
+      eventType: "Quiz Bulk Assigned",
+      eventStatus: "Success",
+      userRole,
+      userName,
+      userIdentifier: userEmail,
+      detailedMessage: `Admin: ${userName}. Quiz ${quizId} bulk-assigned to ${toAssign.length} applicant(s) with role(s): ${roles.join(", ")}. Skipped ${alreadyAssignedIds.size} existing assignment(s).`,
+      request,
+    })
+
+    return new Response(
+      JSON.stringify({ created: toAssign.length, skipped: applicants.length - toAssign.length, roles }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  } catch (e) {
+    await logAuditEvent({
+      eventType: "Quiz Bulk Assigned",
+      eventStatus: "Error",
+      userRole: userRole || "Unknown",
+      userName: userName || "Unknown",
+      userIdentifier: userEmail || "Unknown",
+      detailedMessage: `Failed to bulk-assign quiz: ${e?.message || "Unknown error"}`,
+      request,
+    })
+    return new Response(JSON.stringify({ error: "Failed to bulk assign quiz" }), { status: 500, headers: { "Content-Type": "application/json" } })
+  }
+}

--- a/src/app/api/admin/quizzes/[quizId]/route.js
+++ b/src/app/api/admin/quizzes/[quizId]/route.js
@@ -16,11 +16,17 @@ export async function PUT(request, { params }) {
     const { quizId } = await params
     if (!quizId) return new Response(JSON.stringify({ error: "quizId required" }), { status: 400, headers: { "Content-Type": "application/json" } })
 
+    const VALID_ROLES = ["Nurse", "Receptionist", "Dentist"]
     const body = await request.json().catch(() => ({}))
     const patch = {}
     if (typeof body.pageTitle === "string") patch["Page Title"] = body.pageTitle
     if (typeof body.passingScore !== "undefined" && body.passingScore !== null && body.passingScore !== "") {
       patch["Passing Score"] = Number(body.passingScore)
+    }
+    if (typeof body.targetRole === "string" && VALID_ROLES.includes(body.targetRole)) {
+      patch["fldSHMGQGWUxecF65"] = body.targetRole
+    } else if (body.targetRole === null || body.targetRole === "") {
+      patch["fldSHMGQGWUxecF65"] = null
     }
     if (Object.keys(patch).length === 0) {
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } })

--- a/src/app/api/admin/quizzes/route.js
+++ b/src/app/api/admin/quizzes/route.js
@@ -5,6 +5,7 @@ import { joinOptionsArray } from "@/lib/quiz/options"
 import { logAuditEvent } from "@/lib/auditLogger"
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID)
+const VALID_ROLES = ["Nurse", "Receptionist", "Dentist"]
 
 async function getAdminSession() {
   const cookieStore = await cookies()
@@ -21,7 +22,7 @@ export async function GET() {
     if (!session) return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { "Content-Type": "application/json" } })
 
     const records = await base("Onboarding Quizzes").select({
-      fields: ["Quiz Title", "Passing Score", "Page Title", "Week"]
+      fields: ["Quiz Title", "Passing Score", "Page Title", "Week", "fldSHMGQGWUxecF65"]
     }).all()
 
     const quizzes = records.map((r) => ({
@@ -29,7 +30,8 @@ export async function GET() {
       title: r.get("Quiz Title") || "",
       passingScore: r.get("Passing Score") ?? null,
       pageTitle: r.get("Page Title") || "",
-      week: r.get("Week") ?? null
+      week: r.get("Week") ?? null,
+      targetRole: r.get("Target Roles") || null
     }))
 
     return new Response(JSON.stringify({ quizzes }), { status: 200, headers: { "Content-Type": "application/json" } })
@@ -50,7 +52,7 @@ export async function POST(request) {
     userName = session.userName || userEmail?.split("@")[0]
 
     const body = await request.json().catch(() => ({}))
-    const { title, pageTitle, passingScore, week, items } = body
+    const { title, pageTitle, passingScore, week, items, targetRole } = body
 
     // Validate all required fields
     const errors = []
@@ -88,6 +90,9 @@ export async function POST(request) {
       "Page Title": pageTitle.trim(),
       "Passing Score": passingScore,
       "Week": week
+    }
+    if (typeof targetRole === "string" && VALID_ROLES.includes(targetRole)) {
+      quizFields["fldSHMGQGWUxecF65"] = targetRole
     }
 
     const quizRecord = await base("Onboarding Quizzes").create([{ fields: quizFields }])

--- a/src/app/api/user/quizzes/route.js
+++ b/src/app/api/user/quizzes/route.js
@@ -20,17 +20,21 @@ async function getSessionUser() {
   return user;
 }
 
-async function getApplicantIdByEmail(userEmail) {
+async function getApplicantRecord(userEmail) {
   const applicants = await base(APPLICANTS)
-    .select({ filterByFormula: `{Email} = '${userEmail}'`, maxRecords: 1 })
+    .select({ filterByFormula: `{Email} = '${userEmail}'`, maxRecords: 1, fields: ["Email", "fldd0RHjePJFSOoQP"] })
     .firstPage();
-  return applicants[0]?.id;
+  const record = applicants[0];
+  if (!record) return { id: null, jobName: null };
+  const jobNameField = record.get("Job Name");
+  const jobName = Array.isArray(jobNameField) ? jobNameField[0] || null : jobNameField || null;
+  return { id: record.id, jobName };
 }
 
 export async function GET(request) {
   try {
     const user = await getSessionUser();
-    const applicantId = await getApplicantIdByEmail(user.userEmail);
+    const { id: applicantId, jobName: userJobName } = await getApplicantRecord(user.userEmail);
     if (!applicantId) {
       logger.debug(`No applicant found for email: ${user.userEmail}`);
       return NextResponse.json({ error: "Applicant not found" }, { status: 404 });
@@ -89,6 +93,10 @@ export async function GET(request) {
         }
         
         if (!quizRec || !quizRec.fields) return null;
+
+        // Role gate: if quiz has a target role set, skip if user's job doesn't match
+        const targetRole = quizRec.get("Target Roles") || null;
+        if (targetRole && userJobName && targetRole !== userJobName) return null;
 
         // Find submission for this quiz/applicant
         const submissions = await base(ONBOARDING_QUIZ_SUBMISSIONS)


### PR DESCRIPTION
## Summary

- Adds `Target Role` field support to quizzes (backed by Airtable `Target Roles` singleSelect field ID `fldSHMGQGWUxecF65`) — values: `Nurse`, `Receptionist`, `Dentist`
- Server-side role gate in `/api/user/quizzes`: applicants only see quizzes matching their `Job Name`; quizzes with no target role remain visible to everyone (backward compatible)
- New `POST /api/admin/quizzes/[quizId]/bulk-assign` endpoint: finds all applicants with matching `Job Name`, creates task log records, skips duplicates
- Admin quiz UI updated: Target Role dropdown in create/edit dialogs, role badge on each quiz card, Assign button per quiz

## Files changed

| File | Change |
|---|---|
| `src/app/api/admin/quizzes/route.js` | GET returns `targetRole`; POST saves it |
| `src/app/api/admin/quizzes/[quizId]/route.js` | PUT accepts `targetRole` (pass `null` to clear) |
| `src/app/api/user/quizzes/route.js` | Refactored applicant lookup to return `jobName`; added role filter gate |
| `src/app/api/admin/quizzes/[quizId]/bulk-assign/route.js` | New endpoint — bulk-creates task logs for matching-role applicants |
| `src/app/admin/quizzes/page.js` | Target Role select in create/edit, role badge + Assign button in quiz list |
| `docs/admin-quizzes.md` | Updated with role-based assignment docs and new API contracts |

## Test plan

- [ ] Airtable: confirm `Target Roles` singleSelect field exists in `Onboarding Quizzes` table with options `Nurse`, `Receptionist`, `Dentist`
- [ ] Create quiz with Target Role = Nurse → confirm badge shows "Nurse" on card
- [ ] Edit quiz, change/clear role → confirm badge updates
- [ ] Click **Assign** on Nurse quiz → toast shows created/skipped counts; check Airtable task logs
- [ ] Re-click **Assign** → skipped count matches total, no duplicate task logs
- [ ] Click **Assign** on quiz with no Target Role set → toast error shown
- [ ] Log in as Nurse applicant → quiz appears in dashboard
- [ ] Log in as Receptionist applicant → Nurse quiz does NOT appear
- [ ] Quiz with no Target Role → visible to all roles
- [ ] `npm run lint` passes

## Notes

- Pre-existing test failures (37) on `master` are unrelated to this branch — confirmed by running the suite on both branches
- To add new roles: update `KNOWN_ROLES` in `page.js`, `VALID_ROLES` in both API routes, and add the option to the Airtable field