### PR TITLE
feat: appraisal & applicant drawer notifications for all admins

### DIFF
--- a/TASK-appraisal-manager-notifications.md
+++ b/TASK-appraisal-manager-notifications.md
@@ -144,11 +144,11 @@ try {
 
 ## Sub-tasks
 
-- [ ] **Step 0** — Create this TASK doc (done)
-- [ ] **Step 1** — Extend applicant fetch to include `"Name"` and `"Job Name"` fields; extract `applicantName` + `applicantJobName` from record
-- [ ] **Step 2** — Replace single-admin notification block with all-admins `Promise.all` notify
-- [ ] **Step 3** — Update `docs/appraisal-system.md` to document the notification behaviour
-- [ ] **Step 4** — Commit with message `feat: notify all admins when appraisal date is set`
+- [x] **Step 0** — Create this TASK doc (done)
+- [x] **Step 1** — Extend applicant fetch to include `"Name"` and `"Job Name"` fields; extract `applicantName` + `applicantJobName` from record
+- [x] **Step 2** — Replace single-admin notification block with all-admins `Promise.all` notify
+- [x] **Step 3** — Update `docs/appraisal-system.md` to document the notification behaviour
+- [x] **Step 4** — Commit with message `feat: notify all admins when appraisal date is set`
 
 ---
 

--- a/TASK-appraisal-manager-notifications.md
+++ b/TASK-appraisal-manager-notifications.md
@@ -1,7 +1,7 @@
 # TASK: Appraisal Manager Notifications
 
 **Branch:** `test/notifications-workflow`
-**Status:** In Progress
+**Status:** Complete
 
 ---
 

--- a/TASK-appraisal-manager-notifications.md
+++ b/TASK-appraisal-manager-notifications.md
@@ -1,0 +1,175 @@
+# TASK: Appraisal Manager Notifications
+
+**Branch:** `test/notifications-workflow`
+**Status:** In Progress
+
+---
+
+> ⚠️ **FOR ANY CLAUDE INSTANCE PICKING UP THIS TASK:**
+> Read the current state of every referenced file before implementing.
+> Validate the root cause still exists at the described line numbers — they may have shifted.
+
+---
+
+## Problem
+
+When an admin sets an appraisal date for an applicant, only the admin who performed the action
+receives a notification ("Appraisal Date Updated"). No other admins or managers are informed.
+
+The client needs **all admin/manager accounts** to be notified when an appraisal is scheduled —
+so that the relevant manager (nurse manager, reception manager, etc.) is aware without requiring
+any manual communication.
+
+## Decision: Notify All Admins via Existing `createNotification` Infrastructure
+
+The existing `createNotification` function (`src/lib/notifications.js`) already handles:
+1. Checking if the recipient has `"Appraisal"` enabled in their `Notification Preferences`
+2. Creating an in-app notification record in Airtable `Notifications` table
+3. Firing `MAKE_WEBHOOK_URL_NOTIFICATIONS` for Email/Slack delivery (best-effort, non-fatal)
+
+The Make.com scenario (`docs/handover/automations/onboarding/GENERAL_NOTIFICATIONS.json`) receives
+`{ title, body, type, severity, recipientId, channels }` and:
+- **Email route**: filter `channels contains "Email"` → fetch `Staff.Email` by `recipientId` → send Gmail
+- **Slack route**: filter `channels contains "Slack"` → fetch `Staff["Slack ID"]` by `recipientId` → DM
+
+**No Make.com changes needed.** The webhook payload produced by `createNotification` is already
+compatible with the existing scenario.
+
+The notification message will include the applicant's name and job role so managers can immediately
+see who the appraisal is for without needing to open the platform.
+
+Role-specific routing is handled by the admin's own preferences — if the client later wants
+nurse managers to only receive nurse applicant notifications, a Staff "Department" field and filter
+can be added. For now, all admins get all appraisal notifications, which is the client's request.
+
+---
+
+## Airtable Prerequisites (Client Must Do)
+
+1. In the `Staff` table → `Notification Preferences` multi-select field:
+   - Confirm `"Appraisal"` option exists (it should — it's already a value in the codebase's
+     `NOTIFICATION_TYPES.APPRAISAL = "Appraisal"` constant).
+   - If it doesn't appear in the Airtable field options, add it manually.
+   - Each admin who wants to receive notifications must enable `"Appraisal"` in their preferences
+     via Admin → Profile → Preferences → Notifications.
+
+2. Each admin who wants **email** delivery must also have `"Email"` in their
+   `Notification Channels` field (same Preferences UI).
+
+> If an admin has not enabled the `"Appraisal"` type in their preferences, they will receive
+> **no** in-app notification and no email. This is by design — it respects per-user preferences.
+
+---
+
+## File to Change
+
+**`src/app/api/admin/users/[id]/appraisal-date/route.js`**
+
+### Current behaviour (reference line numbers — verify before editing)
+
+- **Lines 66–73**: Fetches the applicant record from Airtable with fields
+  `[FIELD_APPRAISAL_HISTORY, FIELD_QUESTIONS_OVERRIDE]` to build the appraisal history.
+- **Lines 171–188**: After the Airtable update, queries the Staff record for the
+  **acting admin only** (the one who set the date) and calls `createNotification` once with
+  the message `"Appraisal set to ${dateStr}. An appointment event has been created..."`.
+
+### Required changes
+
+#### Change 1 — Extend the applicant fetch to include Name and Job Name
+
+In the `.select({ ... fields: [...] ... })` call at ~line 68, add `"Name"` and `"Job Name"`
+to the fields array:
+
+```js
+fields: [FIELD_APPRAISAL_HISTORY, FIELD_QUESTIONS_OVERRIDE, "Name", "Job Name"],
+```
+
+After the fetch resolves, extract the values (after the existing `questionsOverrideRaw` line):
+
+```js
+const applicantName = records?.[0]?.get?.("Name") || "Unknown"
+const applicantJobName = records?.[0]?.get?.("Job Name") || "Unknown Role"
+```
+
+#### Change 2 — Replace single-admin notification with all-admins notification
+
+**Remove** the existing notification block (~lines 171–188):
+
+```js
+// Notify acting staff (if Staff record exists)
+try {
+  const staffRecs = await base("Staff").select({ filterByFormula: `{Email}='${...}'`, ... })
+  ...
+  await createNotification({ title: "Appraisal Date Updated", ... })
+} catch (e) { ... }
+```
+
+**Replace** with a query for all admins and a `Promise.all` notify:
+
+```js
+// Notify all admins about the scheduled appraisal
+try {
+  const adminRecs = await base("Staff")
+    .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+    .firstPage()
+  if (adminRecs.length > 0) {
+    await Promise.all(
+      adminRecs.map((admin) =>
+        createNotification({
+          title: "Appraisal Scheduled",
+          body: `${applicantName} (${applicantJobName}) has an appraisal scheduled for ${dateStr}.`,
+          type: NOTIFICATION_TYPES.APPRAISAL,
+          severity: "Info",
+          recipientId: admin.id,
+          actionUrl: "/admin/users",
+          source: "Appraisal",
+        })
+      )
+    )
+  }
+} catch (e) {
+  logger?.error?.("createNotification failed for appraisal date — all admins", e)
+}
+```
+
+> **Why `.firstPage()` is fine here:** The `Staff` table has a small number of admins (typically < 10).
+> Airtable's default page size is 100 records. No pagination needed.
+
+> **Why `Promise.all` instead of sequential:** Each `createNotification` call involves 2 Airtable
+> reads (Staff prefs + Notifications create) plus a non-blocking fetch to Make.com. Running them in
+> parallel cuts response time proportionally to the number of admins. Failures in one do not cancel
+> others — `createNotification` catches internally.
+
+---
+
+## Sub-tasks
+
+- [ ] **Step 0** — Create this TASK doc (done)
+- [ ] **Step 1** — Extend applicant fetch to include `"Name"` and `"Job Name"` fields; extract `applicantName` + `applicantJobName` from record
+- [ ] **Step 2** — Replace single-admin notification block with all-admins `Promise.all` notify
+- [ ] **Step 3** — Update `docs/appraisal-system.md` to document the notification behaviour
+- [ ] **Step 4** — Commit with message `feat: notify all admins when appraisal date is set`
+
+---
+
+## Verification Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npm run dev` → set an appraisal date for a test applicant
+- [ ] In Airtable `Notifications` table: confirm one record per admin was created with
+      `Type = "Appraisal"` and body containing the applicant name and job role
+- [ ] In-app: admin notification bell shows the new notification
+- [ ] If an admin has `"Email"` in their channels + `"Appraisal"` in preferences: confirm email received
+- [ ] If an admin does NOT have `"Appraisal"` in preferences: confirm no record created for them
+      (check `createNotification` logs: `"type='Appraisal' not in preferences — skipping"`)
+
+---
+
+## What is NOT Changing
+
+- No Make.com scenario changes required
+- No new environment variables needed
+- No Airtable schema changes required (just enabling the existing `"Appraisal"` option
+  in each admin's preferences — client action)
+- The route's response shape and status codes are unchanged
+- Audit logging is unchanged

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
 ### Feature Documentation
 - [Task Management](./task-management.md)
 - [Admin Workflows](./admin-workflows.md) — Invite flow, claim/complete flow
+- [Admin & Staff Password Reset](./admin-password-reset.md) — Reset flow for admin accounts
 - [Resource Hub](./resource-hub.md) — Resource browsing, search, filters
 - [Notifications](./notifications.md) — In-app notifications and preferences
 - [Appraisal System](./appraisal-system.md) — Pre-appraisal questions and documents

--- a/docs/admin-password-reset.md
+++ b/docs/admin-password-reset.md
@@ -1,0 +1,125 @@
+# Admin & Staff Password Reset
+
+Covers the full password-reset flow for **admin/staff accounts** (separate from the applicant reset flow).
+
+---
+
+## How it works
+
+There are two independent reset flows depending on who is logging in:
+
+| User type | Login page | Reset flow |
+|-----------|-----------|------------|
+| Applicant / team member | `/` (default tab) | `POST /api/forgot-password` → resets in `Applicants` table |
+| Admin / staff | `/?mode=admin` | `POST /api/admin/forgot-password` → resets in `Staff` table |
+
+Before this was implemented (pre-May 2026), clicking "Forgot password?" on the admin login silently failed — the form showed a success message but no reset email was ever sent, because the route only queried the `Applicants` table.
+
+---
+
+## Admin reset — step by step
+
+1. Go to `/?mode=admin` (the Admin Login tab).
+2. Click **"Forgot password?"** — you are taken to `/forgot-password?isAdmin=true`.
+3. Enter your admin email address and submit.
+4. The server:
+   - Looks up the email in the `Staff` Airtable table (filtered to `IsAdmin = TRUE`).
+   - Writes a one-time `Reset Nonce` to the Staff record.
+   - Signs a 24-hour JWT containing `{ email, nonce, userTable: "Staff" }`.
+   - Fires the `MAKE_WEBHOOK_URL_RESET_PASSWORD` Make.com webhook, which sends the reset email.
+5. Check your inbox — click the **"Reset Password"** link.
+6. The link opens `/reset-password?token=...` — enter and confirm your new password.
+7. The server verifies the JWT, matches the nonce (single-use: clears on success), and updates the bcrypt hash in the `Staff` record.
+8. Log in with the new password on the Admin tab.
+
+> **Token is single-use.** Clicking the same reset link a second time returns "This reset link has already been used."
+
+> **Token expires in 24 hours.** If the link is older than 24 hours, you will need to request a new one.
+
+---
+
+## Applicant reset — step by step
+
+Same flow but without `?isAdmin=true`:
+
+1. Go to `/forgot-password` (no query param) — or click "Forgot password?" on the default login tab.
+2. Enter your applicant email and submit.
+3. The server queries the `Applicants` table and fires the same Make.com webhook.
+4. Reset link opens `/reset-password?token=...`, password is updated in `Applicants`.
+
+---
+
+## API endpoints
+
+### `POST /api/admin/forgot-password`
+Unauthenticated (public route — no session required).
+
+```json
+Body:    { "email": "admin@example.com" }
+Success: { "message": "If that email is registered, a reset link has been sent." }
+Error:   { "error": "..." }  (400 for bad input, 500 for server errors)
+```
+
+Queries `Staff` filtered by `IsAdmin = TRUE()`. Always returns the generic success message even if the email is not found (security: prevents email enumeration).
+
+### `POST /api/forgot-password`
+Unauthenticated (public route).
+
+```json
+Body:    { "email": "applicant@example.com" }
+```
+
+Queries `Applicants` table. Same response shape.
+
+### `POST /api/reset-password`
+Unauthenticated (public route). Used by **both** admin and applicant reset flows.
+
+```json
+Body: { "token": "<jwt>", "password": "...", "confirmPassword": "..." }
+```
+
+Reads `userTable` from the decoded JWT payload (`"Staff"` or `"Applicants"`) and updates the correct table. Validates the nonce before writing and clears it on success.
+
+---
+
+## Airtable requirements
+
+| Table | Field | Type | Purpose |
+|-------|-------|------|---------|
+| `Staff` | `Reset Nonce` | Single line text | One-time token for reset verification |
+| `Applicants` | `Reset Nonce` | Single line text | One-time token for reset verification |
+
+Both fields must exist. If a `Reset Nonce` field is missing, the reset will fail silently (the nonce check will return empty and the link will be rejected as invalid).
+
+---
+
+## Make.com automation
+
+The same scenario (`PASSWORD_RESET_EMAIL`) handles both admin and applicant resets. It uses the reset token from `{{1.resetToken}}` and appends it to the fixed base URL:
+
+```
+https://onboarding-task-manager.vercel.app/reset-password?token={{1.resetToken}}
+```
+
+No changes to the Make.com scenario are needed to support admin resets — the JWT's `userTable` field tells `reset-password` which Airtable table to update.
+
+---
+
+## Password rules (both flows)
+
+- Minimum 8 characters
+- At least one special character (e.g. `!@#$%`)
+- No consecutive sequences (e.g. `123`, `abc`, `012`)
+
+These rules are enforced on both the client (instant feedback) and the server (authoritative check).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| No reset email received | Wrong flow used (admin email submitted on applicant form, or vice versa) | Use `/?mode=admin` → "Forgot password?" for admin accounts |
+| "Invalid or expired token" immediately | Token is older than 24 hours | Request a new reset link |
+| "This reset link has already been used" | Link was already submitted once | Request a new reset link |
+| Form shows success but email never arrives | Make.com scenario paused or Gmail disconnected | Check Make.com dashboard; confirm Gmail connection is active |

--- a/docs/admin-workflows.md
+++ b/docs/admin-workflows.md
@@ -6,25 +6,34 @@ Admins can invite new admin accounts from **Admin → Profile → Create Admin**
 
 ### Flow
 
-1. Admin submits name and email via the profile UI (guarded confirmation dialog)
-2. Server upserts a record in Airtable `Staff` with `IsAdmin = true` and empty `Password`
-3. Server generates a 24-hour JWT invite token (`type: "admin_invite"`, payload: `{ staffId, email }`)
-4. Make.com webhook (`MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE`) sends the invite email with a password-setup link
-5. Invitee opens the link at `/accept-admin-invite?token=...`, sets a password, and can log in
+1. Admin submits name and email via the profile UI (guarded confirmation dialog).
+2. Server upserts a record in Airtable `Staff` with `IsAdmin = true` and empty `Password`.
+   - If the email already has an admin account with a password set → **400 "User already has an admin account"**.
+   - If the email exists but has no password → the record is reused (re-invite). The `Name` field is updated in case it changed.
+   - If the email is new → a fresh `Staff` record is created. If the Make.com webhook fails, the record is **rolled back** (deleted) so Airtable is not left in a partial state.
+3. Server generates a one-time UUID **`Invite Nonce`**, stores it on the Staff record, and signs a 24-hour JWT: `{ staffId, email, type: "admin_invite", nonce }`.
+4. Make.com webhook (`MAKE_WEBHOOK_URL_ADMIN_PASSWORD_PAGE`) sends the invite email with a link to `/accept-admin-invite?token=...`.
+5. Invitee opens the link. The page decodes the JWT client-side on load and shows an **"expired"** warning if the token is older than 24 hours — before the user fills in the form.
+6. Invitee sets a password (8+ chars, special char required, no consecutive sequences) and submits.
+7. Server verifies the JWT signature, checks `type === "admin_invite"`, matches the nonce against Airtable (replay protection), bcrypt-hashes the password, updates the `Staff` record, clears the nonce, and creates an iron-session cookie.
+8. Invitee is redirected to `/admin/dashboard` — already logged in.
+
+> **Invite links are single-use.** If the same link is opened after the password has been set, the server returns "This invite has already been accepted". Re-inviting an address generates a new nonce, silently invalidating the old link.
 
 ### Endpoints
 
 **`POST /api/admin/invite-admin`** — Requires admin session cookie
 ```json
-Body: { "name": "Jane Doe", "email": "jane@example.com" }
-Response: { "message": "Invite sent", "staffId": "recXXX" }
+Body:     { "name": "Jane Doe", "email": "jane@example.com" }
+Success:  { "message": "Invite sent", "staffId": "recXXX" }
+Error:    { "error": "..." }  (400 already configured, 502 webhook failed)
 ```
 
-**`POST /api/admin/accept-invite`**
+**`POST /api/admin/accept-invite`** — Public (no session required)
 ```json
 Body: { "token": "...", "password": "...", "confirmPassword": "..." }
 ```
-Verifies the JWT and updates the `Staff` record with a bcrypt-hashed password.
+Verifies JWT, validates nonce, hashes password, creates session. Returns `{ redirect: "/admin/dashboard" }`.
 
 ### Environment Variables Required
 
@@ -33,12 +42,22 @@ Verifies the JWT and updates the `Staff` record with a bcrypt-hashed password.
 - `SESSION_SECRET`
 - `AIRTABLE_API_KEY`
 - `AIRTABLE_BASE_ID`
+- `NEXT_PUBLIC_APP_URL` (used to build the invite link; falls back to `APP_BASE_URL` if set)
 
 ### Airtable Requirements
 
-`Staff` table must have fields: `Name`, `Email`, `Password`, `IsAdmin`.
+`Staff` table must have fields: `Name`, `Email`, `Password`, `IsAdmin`, **`Invite Nonce`** (Single line text).
 
 All actions are audit-logged to `Website Audit Log` (`User` type for invite/accept, `Server` type for errors).
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| "User already has an admin account" | Email was already onboarded | Use "Forgot password?" on the admin login if they need access |
+| Invite email not received | Make.com scenario paused or Gmail disconnected | Check Make.com; the server returns a 502 with the Make error detail if it fails |
+| "Invalid or expired token" on accept page | Link older than 24h, or re-invite was sent (old link invalidated) | Admin resends the invite — the UI toast shows "Invite sent successfully" when a fresh link is delivered |
+| "This invite has already been accepted" | Password already set on this nonce | Normal — account is active. Use "Forgot password?" if they need a reset |
 
 ---
 
@@ -92,6 +111,21 @@ POST /api/dashboard/tasks/claim-all
 Body: { "applicantId"?: "...", "taskIds"?: ["..."] }
 Response: { "claimed": [...], "alreadyClaimed": [...], "errors": [...] }
 ```
+
+### Optimistic UI behaviour
+
+Claim and unclaim update the badge **immediately** in the UI without waiting for the Airtable round-trip:
+
+- **Claim:** Badge flips from "Unclaimed" to "Claimed" instantly. `fetchTasks()` syncs the real Airtable value in the background.
+- **Unclaim:** Badge reverts to "Unclaimed" instantly. Toast reads "Task unclaimed" with no delay (unclaiming is trivially reversible by re-claiming, so no undo timer is shown).
+
+The three-dot (`⋯`) action button on both claimed and unclaimed task cards shows a **"More actions"** tooltip on hover.
+
+The Unclaim action uses a circular-arrow (↺) icon to distinguish it from Delete (✕).
+
+### Viewing all claimed tasks
+
+On the admin dashboard task view, use the **Status filter** to select **"Claimed"** — this shows every task currently assigned to a staff member. Claimed tasks display the claiming staff member's name alongside the task.
 
 ### Notes
 

--- a/docs/appraisal-system.md
+++ b/docs/appraisal-system.md
@@ -88,14 +88,21 @@ GET  /api/admin/users/[id]/appraisal-template   → job template for applicant's
 POST /api/admin/users/[id]/appraisal-template   → save job template
 ```
 
-### Set appraisal date (with question snapshot)
+### Set appraisal date (with question snapshot and manager notifications)
 
 ```
 POST /api/admin/users/[id]/appraisal-date
 Body: { "date": "YYYY-MM-DD", ... }
 ```
 
-On save, reads the current override questions and stores them as `preappraisalQuestions` in the appraisal history entry.
+On save:
+- Reads the current override questions and stores them as `preappraisalQuestions` in the appraisal history entry.
+- Notifies **all admin accounts** via `createNotification` with the message:
+  `"[Applicant Name] ([Job Role]) has an appraisal scheduled for [date]."`
+  Each admin only receives the notification if `"Appraisal"` is enabled in their
+  `Notification Preferences` (Admin → Profile → Preferences → Notifications).
+  Email/Slack delivery follows each admin's configured channels via the
+  `GENERAL_NOTIFICATIONS` Make.com scenario.
 
 ### Upload appraisal document
 

--- a/docs/monthly-reviews.md
+++ b/docs/monthly-reviews.md
@@ -56,6 +56,12 @@ DELETE /api/admin/users/:id/monthly-reviews/:reviewId
 
 > **Note:** If a Google Calendar event was created when scheduling, it is **not** automatically deleted — the Calendar event ID is not currently persisted to Airtable. This can be extended by storing the event ID on the Monthly Review record.
 
+## Booking conflict detection
+
+When selecting a date/time for a review, the booking UI checks your Google Calendar for conflicts and disables the Confirm button if a clash is detected.
+
+> **All-day events (holidays, full-day blocks) are intentionally excluded from conflict detection.** Only timed events can block a booking slot. If the Confirm button appears disabled with no visible conflict, check whether the admin calendar has an all-day event on that date — all-day events should never prevent booking.
+
 ## UI Behavior
 
 In the applicant drawer → Monthly Reviews section:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -52,6 +52,41 @@ Both endpoints are audit-logged. PUT logs a success event with a summary of chan
 **Notifications table fields:**
 - `Title`, `Body`, `Severity`, `Recipient` (link to Staff), `Read`, `Action URL`, `Source`, `Type`
 
+### Required `Notification Preferences` options
+
+The `Notification Preferences` field must have these exact option strings (case-sensitive — the code's `preferences.includes(type)` check is strict). Cross-referenced against `docs/ATS_schema.json` May 2026:
+
+| Option string | Status | Triggered by |
+|---|---|---|
+| `Task Assignment` | ✅ exists | Task assigned to applicant |
+| `Task Completion` | ✅ exists | Task marked complete |
+| `Task Update` | ✅ exists | Task updated |
+| `Task Deletion` | ✅ exists | Task deleted |
+| `Task Unclaimed` | ✅ exists | Task unclaimed |
+| `Task Flagged` | ✅ exists | Task flagged |
+| `Task Flag Resolved` | ✅ exists | Flag resolved |
+| `Task Flag Resolved & Completed` | ✅ exists | Flag resolved and completed |
+| `Task Claim-All Executed` | ✅ exists | Bulk claim-all action |
+| `Document Upload` | ✅ exists | Document uploaded |
+| `Quiz Completion` | ✅ exists | Quiz passed |
+| `Quiz Failed` | ❌ missing | Quiz failed — **add this option** |
+| `Applicant Stage Updated` | ✅ exists | Stage advanced, rejected, or overridden |
+| `Onboarding Paused` | ✅ exists | Onboarding paused |
+| `Onboarding Resumed` | ✅ exists | Onboarding resumed |
+| `Onboarding started` | ✅ exists | Onboarding started (note lowercase 's' — matches code) |
+| `New Hire Added` | ✅ exists | New hire record created |
+| `Admin Invited` | ✅ exists | Admin invite sent |
+| `Admin Invite Accepted` | ✅ exists | Admin accepted invite |
+| `Appraisal` | ❌ missing | Appraisal date set, appraisal doc uploaded — **add this option** |
+| `Monthly Review` | ❌ missing | Monthly review scheduled — **add this option** |
+| `Monthly Review Cancelled` | ❌ missing | Monthly review deleted — **add this option** |
+| `Announcement` | ✅ exists | System announcement |
+| `Custom` | ✅ exists | Custom notification |
+
+> **Missing options cause silent failures.** If an option string doesn't exist in the field, `createNotification` cannot match it against any admin's saved preferences and will silently skip the notification — no error is thrown.
+
+> **Adding a new notification type** requires: (1) add a constant to `src/lib/notification-types.js`, (2) add the matching option to `Staff → Notification Preferences` in Airtable, (3) call `createNotification` with that type in the relevant route.
+
 ## Scalable Architecture (Future)
 
 The current implementation uses flat multi-select fields on the `Staff` table. A more scalable approach would introduce:

--- a/src/app/admin/users/actions.js
+++ b/src/app/admin/users/actions.js
@@ -74,6 +74,32 @@ export async function updateApplicant(payload) {
     } catch (err) {
       logger?.error?.("audit log failed for updateApplicant", err)
     }
+
+    // Notify all admins of the stage change
+    try {
+      const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID)
+      const adminRecs = await base("Staff")
+        .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+        .firstPage()
+      if (adminRecs.length > 0) {
+        await Promise.all(
+          adminRecs.map((admin) =>
+            createNotification({
+              title: "Applicant Stage Updated",
+              body: `${existing.name || "Unknown"}: stage changed from "${existing.stage || "none"}" to "${stage}".`,
+              type: NOTIFICATION_TYPES.APPLICANT_STAGE_UPDATED,
+              severity: "Info",
+              recipientId: admin.id,
+              actionUrl: "/admin/users",
+              source: "Applicant Drawer",
+            })
+          )
+        )
+      }
+    } catch (err) {
+      logger?.error?.("createNotification failed for stage update — all admins", err)
+    }
+
     return result
   }
 

--- a/src/app/api/admin/users/[id]/appraisal-date/route.js
+++ b/src/app/api/admin/users/[id]/appraisal-date/route.js
@@ -72,7 +72,7 @@ export async function POST(request, { params }) {
         .firstPage()
 
       const applicantName = records?.[0]?.get?.("Name") || "Unknown"
-      const applicantJobName = records?.[0]?.get?.("Job Name") || "Unknown Role"
+      const applicantJobName = records?.[0]?.get?.("Job Name")?.[0] || "Unknown Role"
 
       const existingHistoryRaw = records?.[0]?.get?.(FIELD_APPRAISAL_HISTORY)
 

--- a/src/app/api/admin/users/[id]/appraisal-date/route.js
+++ b/src/app/api/admin/users/[id]/appraisal-date/route.js
@@ -66,13 +66,16 @@ export async function POST(request, { params }) {
       const records = await base("Applicants")
         .select({ 
           filterByFormula: `RECORD_ID() = '${id}'`, 
-          fields: [FIELD_APPRAISAL_HISTORY, FIELD_QUESTIONS_OVERRIDE], 
-          maxRecords: 1 
+          fields: [FIELD_APPRAISAL_HISTORY, FIELD_QUESTIONS_OVERRIDE, "Name", "Job Name"],
+          maxRecords: 1
         })
         .firstPage()
 
+      const applicantName = records?.[0]?.get?.("Name") || "Unknown"
+      const applicantJobName = records?.[0]?.get?.("Job Name") || "Unknown Role"
+
       const existingHistoryRaw = records?.[0]?.get?.(FIELD_APPRAISAL_HISTORY)
-      
+
       // Get current questions override for snapshot
       const questionsOverrideRaw = records?.[0]?.get?.(FIELD_QUESTIONS_OVERRIDE)
       let questionsSnapshot = null
@@ -168,23 +171,28 @@ export async function POST(request, { params }) {
       logger?.error?.("audit log failed for appraisal date update", e)
     }
 
-    // Notify acting staff (if Staff record exists)
+    // Notify all admins about the scheduled appraisal
     try {
-      const staffRecs = await base("Staff").select({ filterByFormula: `{Email}='${String(session.userEmail).toLowerCase()}'`, maxRecords: 1 }).firstPage()
-      const staff = staffRecs?.[0]
-      if (staff) {
-        await createNotification({
-          title: "Appraisal Date Updated",
-          body: `Appraisal set to ${dateStr}. An appointment event has been created in the calendar.`,
-          type: NOTIFICATION_TYPES.APPRAISAL,
-          severity: "Info",
-          recipientId: staff.id,
-          actionUrl: "/admin/users",
-          source: "Applicant Drawer",
-        })
+      const adminRecs = await base("Staff")
+        .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+        .firstPage()
+      if (adminRecs.length > 0) {
+        await Promise.all(
+          adminRecs.map((admin) =>
+            createNotification({
+              title: "Appraisal Scheduled",
+              body: `${applicantName} (${applicantJobName}) has an appraisal scheduled for ${dateStr}.`,
+              type: NOTIFICATION_TYPES.APPRAISAL,
+              severity: "Info",
+              recipientId: admin.id,
+              actionUrl: "/admin/users",
+              source: "Appraisal",
+            })
+          )
+        )
       }
     } catch (e) {
-      logger?.error?.("createNotification failed for appraisal date update", e)
+      logger?.error?.("createNotification failed for appraisal date — all admins", e)
     }
 
     return new Response(JSON.stringify({ success: true, id, appraisalDate: dateStr }), { status: 200, headers: { "Content-Type": "application/json" } })

--- a/src/app/api/admin/users/[id]/appraisal/route.js
+++ b/src/app/api/admin/users/[id]/appraisal/route.js
@@ -2,6 +2,8 @@ import { cookies } from "next/headers"
 import { unsealData } from "iron-session"
 import Airtable from "airtable"
 import logger from "@/lib/utils/logger"
+import { createNotification } from "@/lib/notifications"
+import { NOTIFICATION_TYPES } from "@/lib/notification-types"
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID)
 
@@ -73,6 +75,30 @@ export async function POST(request, { params }) {
     for (const file of files) {
       await uploadFileToAirtable(id, fieldName, file)
       uploaded.push({ name: file.name, size: file.size, type: file.type })
+    }
+
+    // Notify all admins that the appraisal document has been uploaded
+    try {
+      const adminRecs = await base("Staff")
+        .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+        .firstPage()
+      if (adminRecs.length > 0) {
+        await Promise.all(
+          adminRecs.map((admin) =>
+            createNotification({
+              title: "Appraisal Document Uploaded",
+              body: `Appraisal document uploaded for ${applicantName}.`,
+              type: NOTIFICATION_TYPES.APPRAISAL,
+              severity: "Info",
+              recipientId: admin.id,
+              actionUrl: "/admin/users",
+              source: "Applicant Drawer",
+            })
+          )
+        )
+      }
+    } catch (e) {
+      logger?.error?.("createNotification failed for appraisal doc upload — all admins", e)
     }
 
     return new Response(

--- a/src/app/api/admin/users/[id]/monthly-review/route.js
+++ b/src/app/api/admin/users/[id]/monthly-review/route.js
@@ -28,6 +28,12 @@ export async function POST(request, { params }) {
     const title = String(body?.title || "Monthly Review").trim()
     if (!dateStr) return new Response(JSON.stringify({ error: "date is required (YYYY-MM-DD)" }), { status: 400 })
 
+    // Fetch applicant name for notification message
+    const applicantRecs = await base("Applicants")
+      .select({ filterByFormula: `RECORD_ID() = '${id}'`, fields: ["Name"], maxRecords: 1 })
+      .firstPage()
+    const applicantName = applicantRecs?.[0]?.get?.("Name") || "Unknown"
+
     // Create Monthly Reviews record instead of appending free-text
     const period = `${dateStr.slice(0, 7)}` // YYYY-MM
     const startDateTime = startTime ? `${dateStr}T${startTime}:00` : null
@@ -59,23 +65,28 @@ export async function POST(request, { params }) {
       logger?.error?.("audit log failed for monthly review", e)
     }
 
-    // Try to notify acting staff (if Staff record exists)
+    // Notify all admins of the scheduled monthly review
     try {
-      const staffRecs = await base("Staff").select({ filterByFormula: `{Email}='${String(session.userEmail).toLowerCase()}'`, maxRecords: 1 }).firstPage()
-      const staff = staffRecs?.[0]
-      if (staff) {
-        await createNotification({
-          title: "Monthly Review Scheduled",
-          body: `${title} on ${dateStr}${startTime && endTime ? ` ${startTime}-${endTime}` : ""}`,
-          type: NOTIFICATION_TYPES.MONTHLY_REVIEW,
-          severity: "Info",
-          recipientId: staff.id,
-          actionUrl: "/admin/users",
-          source: "Applicant Drawer",
-        })
+      const adminRecs = await base("Staff")
+        .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+        .firstPage()
+      if (adminRecs.length > 0) {
+        await Promise.all(
+          adminRecs.map((admin) =>
+            createNotification({
+              title: "Monthly Review Scheduled",
+              body: `${applicantName} has a monthly review scheduled for ${dateStr}${startTime && endTime ? ` ${startTime}–${endTime}` : ""}.`,
+              type: NOTIFICATION_TYPES.MONTHLY_REVIEW,
+              severity: "Info",
+              recipientId: admin.id,
+              actionUrl: "/admin/users",
+              source: "Applicant Drawer",
+            })
+          )
+        )
       }
     } catch (e) {
-      logger?.error?.("createNotification failed for monthly review", e)
+      logger?.error?.("createNotification failed for monthly review — all admins", e)
     }
 
     return new Response(

--- a/src/app/api/admin/users/[id]/stage/route.js
+++ b/src/app/api/admin/users/[id]/stage/route.js
@@ -3,6 +3,8 @@ import { unsealData } from "iron-session"
 import Airtable from "airtable"
 import logger from "@/lib/utils/logger"
 import { logAuditEvent } from "@/lib/auditLogger"
+import { createNotification } from "@/lib/notifications"
+import { NOTIFICATION_TYPES } from "@/lib/notification-types"
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID)
 
@@ -22,9 +24,10 @@ export async function POST(request, { params }) {
     const source = String(body?.source || "Stage Override").trim()
     if (!newStage) return new Response(JSON.stringify({ error: "newStage is required" }), { status: 400, headers: { "Content-Type": "application/json" } })
 
-    // Get existing stage for audit
+    // Get existing stage and name for audit + notifications
     const applicantRec = await base("Applicants").find(id)
     const prevStage = applicantRec.get("Stage") || ""
+    const applicantName = applicantRec.get("Name") || "Unknown"
 
     // Update stage
     await base("Applicants").update([{ id, fields: { Stage: newStage } }])
@@ -42,6 +45,30 @@ export async function POST(request, { params }) {
       })
     } catch (e) {
       logger?.error?.("audit log failed for stage override", e)
+    }
+
+    // Notify all admins of the stage change
+    try {
+      const adminRecs = await base("Staff")
+        .select({ filterByFormula: "{IsAdmin} = TRUE()", fields: ["Name"] })
+        .firstPage()
+      if (adminRecs.length > 0) {
+        await Promise.all(
+          adminRecs.map((admin) =>
+            createNotification({
+              title: "Applicant Stage Updated",
+              body: `${applicantName}: stage changed from "${prevStage || "none"}" to "${newStage}".`,
+              type: NOTIFICATION_TYPES.APPLICANT_STAGE_UPDATED,
+              severity: "Info",
+              recipientId: admin.id,
+              actionUrl: "/admin/users",
+              source: "Applicant Drawer",
+            })
+          )
+        )
+      }
+    } catch (e) {
+      logger?.error?.("createNotification failed for stage update — all admins", e)
     }
 
     return new Response(JSON.stringify({ success: true, id, prevStage, newStage }), { status: 200, headers: { "Content-Type": "application/json" } })

--- a/src/lib/notification-types.js
+++ b/src/lib/notification-types.js
@@ -31,7 +31,7 @@ export const NOTIFICATION_TYPES = {
   APPLICANT_STAGE_UPDATED:       "Applicant Stage Updated",
   ONBOARDING_PAUSED:             "Onboarding Paused",
   ONBOARDING_RESUMED:            "Onboarding Resumed",
-  ONBOARDING_STARTED:            "Onboarding Started",
+  ONBOARDING_STARTED:            "Onboarding started",
   NEW_HIRE_ADDED:                "New Hire Added",
 
   // Admin


### PR DESCRIPTION
## Summary

- **Appraisal manager notifications**: when an appraisal date is set, all admin accounts are notified (was: acting admin only). Notification body includes applicant name and job role.
- **Full drawer notification coverage**: all major actions in the applicant drawer now call `createNotification` for every admin — stage advance, reject, override (both via `actions.js` and `stage/route.js`), appraisal document upload, and monthly review scheduling.
- **Monthly review fix**: replaced acting-admin-only pattern with all-admins; added applicant name to message body.
- **Bug fix**: `Job Name` field is `multipleLookupValues` (returns array) — added `?.[0]` to extract the string correctly in `appraisal-date/route.js`.
- **Bug fix**: `ONBOARDING_STARTED` constant was `"Onboarding Started"` but Airtable option is `"Onboarding started"` — case mismatch caused silent notification failures. Fixed in `notification-types.js`.
- **Docs**: `docs/notifications.md` updated with a full cross-referenced table of all `Notification Preferences` options vs Airtable schema, including which are missing and what triggers each type.
- **Docs**: `docs/appraisal-system.md` updated to document notification behaviour on appraisal date set.
- **Docs**: `docs/admin-workflows.md`, `docs/monthly-reviews.md`, `docs/admin-password-reset.md` (new) documenting PRs #66/#67/#68.

## Files changed

| File | Change |
|---|---|
| `src/app/api/admin/users/[id]/appraisal-date/route.js` | All-admins notify; fix `Job Name` array bug |
| `src/app/api/admin/users/[id]/stage/route.js` | All-admins notify on reject/override |
| `src/app/admin/users/actions.js` | All-admins notify on normal stage advance |
| `src/app/api/admin/users/[id]/appraisal/route.js` | All-admins notify on appraisal doc upload |
| `src/app/api/admin/users/[id]/monthly-review/route.js` | All-admins notify; add applicant name |
| `src/lib/notification-types.js` | Fix `ONBOARDING_STARTED` case mismatch |
| `docs/notifications.md` | Full Airtable option audit table |
| `docs/appraisal-system.md` | Document notification on appraisal date set |
| `docs/admin-password-reset.md` | New — admin/staff password reset flow |
| `docs/admin-workflows.md` | Updated invite hardening + claim/unclaim UX |
| `docs/monthly-reviews.md` | All-day event conflict detection note |

## Airtable manual steps required

Add these missing options to `Staff → Notification Preferences` (multipleSelects) in Airtable:

- `Appraisal` — without this, appraisal notifications silently skip all admins
- `Monthly Review` — without this, monthly review notifications silently skip all admins
- `Quiz Failed` *(optional)* — pre-existing gap
- `Monthly Review Cancelled` *(optional)* — pre-existing gap

## Test plan

- [ ] Set an appraisal date for any applicant → confirm all admin accounts receive an in-app notification with applicant name and job role
- [ ] Upload an appraisal document → confirm all admin accounts receive an in-app notification
- [ ] Advance an applicant's stage → confirm all admin accounts receive a stage-updated notification
- [ ] Reject an applicant → confirm notification fires
- [ ] Override stage → confirm notification fires
- [ ] Schedule a monthly review → confirm all admins notified with applicant name and date
- [ ] Confirm admins with `Email` channel enabled receive email via Make.com
- [ ] Confirm admins without `Appraisal` in preferences receive no notification (check server logs for `skipping` message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)